### PR TITLE
Engine resilience: --keep-loaded validation + /warm endpoint + cancellable LoKr precompute + wrapper warm-on-startup

### DIFF
--- a/.work/wrapper_resilience_progress.md
+++ b/.work/wrapper_resilience_progress.md
@@ -117,3 +117,89 @@ Decisions:
    fix; they're a lib/tsconfig target issue that touches code unrelated to
    `/status`.
 
+### 2026-06-07 — C2 done: engine + wrapper resilience patches
+
+Seven commits on top of the C3 baseline. Sub-task → commit:
+
+- **2a** `de1be40` `feat(engine): honor per-request ?keep_loaded=1 on /synth and /lm`
+- **2b** `6d9873c` `feat(engine): expose JobPhase + step/total on /job response`
+- **2c** `a084a08` `feat(engine): cancellable LoKr precompute (cooperative cancel during 17s adapter-load)`
+- **2d** `0f31401` `feat(engine): POST /warm endpoint for pre-loading DiT + adapter`
+- **2e** `69db1ab` `feat(engine): GET /jobs enumeration for external reconcilers`
+- **2f** `ea08b7c` `docs(engine): TODO note for dedicated /logs SSE thread pool (F8)` (skipped per task brief; rationale logged in `handle_logs` comment)
+- **2g** `97d01ed` `feat(wrapper): consume engine phase + add warm/listJobs client methods`
+
+Decisions (non-obvious):
+
+1. **`apply_keep_loaded_if_requested` is one-way and idempotent.** The
+   query-param hook flips `g_keep_loaded` true + `store_set_policy(NEVER)`
+   and never reverses. Mixing STRICT and NEVER on the same long-lived
+   process would create non-deterministic eviction behavior; "once a
+   request asks for keep_loaded, we stay loaded" matches the existing
+   `--keep-loaded` semantics exactly and is the simplest contract for
+   the wrapper to reason about.
+2. **`JobPhase` is one atomic per field, not a struct with a mutex.** The
+   worker writes phase transitions every few ms; observers (GET /job) read
+   them on every poll. A mutex would force serialization between hot read
+   and hot write paths for no correctness gain — atomic load/store with
+   the existing seq_cst-on-status contract is sufficient. `job_set_phase`
+   helper bundles step/total reset so external observers never see a stale
+   counter from the previous phase.
+3. **Adapter cancel uses an inline atomic in `adapter-cancel.h`, not a
+   threaded callback parameter.** Threading a `std::function<bool()>`
+   through `ace_synth_load → adapter_load_runtime → adapter_runtime_lokr`
+   would change three public signatures. An inline atomic pointer set by
+   the worker (and RAII-cleared) requires no API change and is correct
+   because the engine runs a single FIFO worker thread by construction.
+   Sub-100 ms cancel granularity (one delta-loop iteration) is fine.
+4. **Split `adapter-cancel.h` out of `adapter-runtime.h`.** Pulling
+   adapter-runtime.h into ace-server.cpp would transitively drag in ggml +
+   safetensors headers (huge compile-time cost, plus every `static` helper
+   in adapter-runtime.h becomes an unused TU-local symbol). The split
+   keeps adapter-runtime.h heavy and adapter-cancel.h tiny.
+5. **/warm worker checks `g_loaded_dit/adapter/vae` sticky names for the
+   idempotent fast-path.** When the same combo is already loaded the worker
+   returns `{warm:true, already_loaded:true}` without touching the store.
+   This is what makes /warm safe to call on every job — no work if nothing
+   changed.
+6. **/warm returns `{warm:false, reason:"keep_loaded not set"}` under STRICT
+   instead of erroring.** Under STRICT the loaded modules would be evicted
+   immediately, making the warm a waste. A 200 with `warm:false` lets the
+   wrapper detect "this engine isn't configured for keep-loaded" without
+   parsing error strings.
+7. **Wrapper default is `keepLoaded=true`.** Cold-start LoKr precompute
+   is ~17 s, hot-start ~50 ms. For an interactive product, keep-loaded is
+   the correct default. `ACESTEPCPP_KEEP_LOADED=0` opts out for VRAM-
+   constrained dev boxes carrying multiple DiT+adapter combos.
+8. **`pollUntilDone` writes `acePhase/acePhaseProgress` on EVERY poll.**
+   Even when status hasn't changed, the phase or sub-step probably has —
+   the stall watchdog already keys on `job.stage/progress` changes for
+   liveness, so refreshing the engine-side phase fields on every tick
+   doesn't perturb that path.
+9. **2f (SSE thread pool) skipped, not deferred to a vague "later".**
+   Inline TODO comment in `handle_logs` documents the constraint (httplib
+   only exposes one `new_task_queue` factory; per-route pools need either
+   a second listener or a hand-rolled dispatcher). Means the next person
+   to touch /logs doesn't have to rediscover the limitation.
+
+Build verification:
+
+- `cmake -S engine -B engine/build` fails on a pre-existing missing
+  submodule (`engine/ggml/CMakeLists.txt` absent — `git submodule update`
+  was not run on this checkout). Not a C2 issue. The user can run a real
+  build whenever they want.
+- `cd server && npm run typecheck` returns the same 4 pre-existing
+  `findLast` errors as before. Zero new errors from C2.
+
+Files touched:
+
+- engine/tools/ace-server.cpp (all engine sub-tasks)
+- engine/src/adapter-cancel.h (NEW; 2c)
+- engine/src/adapter-runtime.h (2c)
+- server/src/services/aceClient.ts (2g)
+- server/src/routes/generate.ts (2g)
+- server/src/index.ts (2g)
+- server/src/config.ts (2g)
+
+Status: all required sub-tasks (2a–2e, 2g) complete. 2f intentionally
+skipped per task brief with rationale logged in code.

--- a/.work/wrapper_resilience_progress.md
+++ b/.work/wrapper_resilience_progress.md
@@ -72,3 +72,48 @@ job, and writes audio that nobody collects.
 ## Decisions log
 
 <!-- Subsequent components append dated entries here as work proceeds. -->
+
+### 2026-06-07 — C3 done: /status surfaces ace_job_id + ace_phase + ace_phase_progress
+
+Modified `server/src/routes/generate.ts` (GET `/api/generate/status/:id` handler
+at L1282) and `server/src/routes/inspire.ts` (GET `/api/inspire/status/:id`
+handler at L193) to include three new fields in the response object:
+
+- `ace_job_id: job.aceJobId ?? null` — already tracked on the Job/InspireJob,
+  just not exposed. C1's reconcile path in `apps/ose/acestep/run.py` uses
+  this to correlate wrapper failures with engine `/jobs/:id` state on :8085.
+- `ace_phase: (job as any).acePhase ?? null` — placeholder for C2 (engine
+  `JobPhase` enum will be threaded into the wrapper Job). Stays `null` for
+  now; adding the field future-proofs the surface so we don't need a second
+  wrapper patch when C2 lands.
+- `ace_phase_progress: (job as any).acePhaseProgress ?? null` — same
+  rationale, sub-phase progress (e.g., "lokr_precompute 42%") future-tracks
+  for C2.
+
+Decisions:
+
+1. **Snake_case field names** (`ace_job_id`, not `aceJobId`). The companion
+   `run.py` consumer is Python and would have to camel->snake convert
+   otherwise. Existing wrapper fields stay camelCase (`jobId`, etc.) — we
+   are adding, not renaming.
+2. **`(job as any)` cast for the two C2 fields** is intentional. The Job
+   interface doesn't yet have `acePhase` / `acePhaseProgress` and we don't
+   want to ship a type change in C3 that would force a follow-up edit when
+   C2 lands. C2 will widen the Job interface properly.
+3. **`null` over `undefined`.** JSON.stringify drops `undefined` keys, which
+   would make the field's absence indistinguishable from a missing field on
+   the consumer side. Explicit `null` means "field exists, value not yet
+   set" which is what run.py's reconcile branches on.
+4. **Mirrored the change in `inspire.ts` for symmetry** per task brief. Did
+   NOT touch `stemStudio` / `coverArt` / `supersep` (out of scope for C3 and
+   they don't go through the same ace-server stall failure mode in C1).
+5. **No `dist/` rebuild, no daemon restart.** The wrapper is served from
+   `server/dist/` at runtime. User reviews the change first; deciding when
+   to rebuild and restart is on them.
+6. **Typecheck:** `npm run typecheck` reports 4 pre-existing `findLast`
+   errors at `generate.ts:246` and `:647` that exist on the base branch
+   too (verified with `git stash` + recheck). My 3-field addition introduces
+   zero new errors. The pre-existing errors are not C3's responsibility to
+   fix; they're a lib/tsconfig target issue that touches code unrelated to
+   `/status`.
+

--- a/.work/wrapper_resilience_progress.md
+++ b/.work/wrapper_resilience_progress.md
@@ -1,0 +1,74 @@
+# Wrapper Resilience — Progress Log (HOT-Step-CPP)
+
+Branch: `feat/wrapper-resilience-hotstep` (off `origin/master`)
+Companion branch: `orinmi-New feat/wrapper-resilience-runpy` (off `origin/fresh_build`)
+
+This repo is third-party (github.com/scragnog/HOT-Step-CPP). We patch locally
+on this dev box. Commits stay on the local feature branch. We do NOT push to
+`scragnog/HOT-Step-CPP`. Whether to submit a courtesy PR upstream is the
+user's call after review.
+
+## Failure context (Jun 6 production incident)
+
+Cold-start LoKr precompute in the C++ engine takes ~17s. During that window
+the httplib-backed ace-server (single-threaded ThreadPool, port :8085) stalls
+and does not respond to status polls. The node wrapper's `pollUntilDone`
+fetches the status exactly once with no retry, sees `fetch failed`, marks the
+wrapper job failed, and returns an error to its caller.
+
+The caller is the orinmi-New worker code path:
+
+```
+Studio /api/music/render
+  -> Supabase queue
+    -> orinmi-New worker (apps/ose/worker-supabase.py)
+      -> apps/ose/acestep/run.py
+        -> HOT-Step-CPP node wrapper :3001
+          -> ace-server (C++) :8085
+```
+
+`run.py:249` raises on the wrapper error. The Supabase render row transitions
+to `failed`. The C++ engine, meanwhile, keeps running cleanly, finishes the
+job, and writes audio that nobody collects.
+
+## 3-component plan (user-chosen scope)
+
+- **C1 — apps/ose/acestep/run.py resilience (companion repo, production unblock):**
+  Classified retry on transient wrapper errors, plus engine-direct reconcile
+  via :8085 so we don't lose work the C++ engine actually produced.
+
+- **C2 — HOT-Step-CPP engine C++ patch (THIS REPO):**
+  - Cancellable LoKr precompute.
+  - `JobPhase` enum.
+  - New `/warm`, `/jobs` endpoints.
+  - Honor `?keep_loaded=1` and `--keep-loaded` engine flag forwarded by the
+    wrapper.
+  - Eliminates the 17s cold-start cost so the stall stops happening at all.
+  - **DO NOT run a full cmake build in a workflow agent** (5+ minutes, blocks
+    the workflow). Configure-only (`cmake -S engine -B engine/build`) is fine;
+    actual compile is the user's call.
+
+- **C3 — HOT-Step-CPP node wrapper patch (THIS REPO, tiny):**
+  - Expose `ace_job_id` and `ace_phase` in `GET /api/generate/status/:id`.
+  - ~3 lines of TS. Lets companion `run.py` correlate wrapper jobs to engine
+    jobs cleanly when reconciling via :8085.
+
+## User decisions
+
+- **No upstream push.** Local-only feature branch. Courtesy PR is the user's
+  decision after review.
+- **No daemon restart.** Do NOT restart `hotstep-server.service` or
+  `acestep-server.service` during this work — would destabilize the running
+  smoke-test environment.
+- **Ultracode mode.** Subagents must branch from the correct base, never
+  commit to integration branches directly, and never use `--no-verify` /
+  `--no-gpg-sign`.
+- **Commit hygiene.** No "Co-Authored-By: Claude" / no Anthropic mention in
+  commit messages. Plain subjects, author defaults to repo config.
+- **Pre-existing dirty files in this repo** (`server/package-lock.json`,
+  `ui/package-lock.json`) are NOT to be staged or committed by this work.
+  Same for the untracked `AUDIT_FIX_PROGRESS.md`.
+
+## Decisions log
+
+<!-- Subsequent components append dated entries here as work proceeds. -->

--- a/engine/src/adapter-cancel.h
+++ b/engine/src/adapter-cancel.h
@@ -1,0 +1,25 @@
+#pragma once
+// adapter-cancel.h: cooperative cancel hook for the LoKr/LoRA delta precompute.
+//
+// The precompute loops in adapter-runtime.h read `g_adapter_cancel` between
+// every delta. The ace-server worker (engine/tools/ace-server.cpp) sets it
+// to point at the active job's atomic<bool> cancel flag right before calling
+// ace_synth_load and clears it after. Without this hook a wrapper-side
+// cancel during the 17 s cold-start adapter precompute has no effect — the
+// load runs to completion before the engine can react.
+//
+// Split into its own header so ace-server.cpp does not need to pull in all
+// of adapter-runtime.h's heavy ggml/safetensors transitive dependencies.
+
+#include <atomic>
+
+// Set by the worker around ace_synth_load (and similar load paths). Reads
+// from inside the precompute loops are cheap (one acquire-load + one
+// relaxed-load on the pointee). C++17 `inline` keeps a single instance
+// across translation units.
+inline std::atomic<const std::atomic<bool> *> g_adapter_cancel{ nullptr };
+
+inline bool adapter_cancel_requested() {
+    const std::atomic<bool> * flag = g_adapter_cancel.load(std::memory_order_acquire);
+    return flag != nullptr && flag->load(std::memory_order_relaxed);
+}

--- a/engine/src/adapter-runtime.h
+++ b/engine/src/adapter-runtime.h
@@ -11,6 +11,7 @@
 // Reuses the same safetensors parsing and delta graph construction from
 // adapter-merge.h — only the merge step is replaced with delta storage.
 
+#include "adapter-cancel.h"
 #include "adapter-merge.h"
 #include "ggml-backend.h"
 #include "ggml.h"
@@ -20,6 +21,10 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+// Cooperative cancel for the LoKr/LoRA delta precompute loop lives in
+// adapter-cancel.h so ace-server.cpp can poke at it without pulling all of
+// adapter-runtime.h's transitive ggml/safetensors deps. See that header.
 
 // Per-projection runtime LoRA delta (stored as BF16 tensor in VRAM)
 struct DiTLoRADelta {
@@ -166,7 +171,8 @@ static bool adapter_runtime_lora(DiTLoRA *                  lora,
         else if (lora_is_b(e.name)) b_map[base] = &e;
     }
 
-    int merged = 0, skipped = 0;
+    int  merged = 0, skipped = 0;
+    bool cancelled = false;
 
     // Determine precision-rounding type for delta computation.
     // BF16 is ideal (matches storage format) but requires a bf16→f32 copy
@@ -182,6 +188,17 @@ static bool adapter_runtime_lora(DiTLoRA *                  lora,
     }
 
     for (const auto & kv : a_map) {
+        // Cooperative cancel: check between every delta. The dominant cost
+        // inside the body is adapter_compute_delta (GPU graph build + run),
+        // which is non-trivial to interrupt — best we can do is stop
+        // queueing more work.  Sub-100ms granularity in practice.
+        if (adapter_cancel_requested()) {
+            fprintf(stderr, "[Adapter-RT] LoRA: cancelled at delta %d (merged=%d, skipped=%d)\n",
+                    merged + skipped, merged, skipped);
+            cancelled = true;
+            break;
+        }
+
         const std::string & gguf_name = kv.first;
         const STEntry *     ea        = kv.second;
 
@@ -298,6 +315,9 @@ static bool adapter_runtime_lora(DiTLoRA *                  lora,
         merged++;
     }
 
+    if (cancelled) {
+        return false;
+    }
     fprintf(stderr, "[Adapter-RT] LoRA: %d deltas precomputed (%d skipped), scale=%.2f\n", merged, skipped, scale);
     return merged > 0;
 }
@@ -331,10 +351,21 @@ static bool adapter_runtime_lokr(DiTLoRA *                  lora,
     }
 
     std::unordered_map<std::string, std::string> name_map = lokr_build_reverse_map(ws);
-    int lokr_dim = adapter_read_lokr_dim(st);
-    int merged = 0, skipped = 0;
+    int  lokr_dim = adapter_read_lokr_dim(st);
+    int  merged = 0, skipped = 0;
+    bool cancelled = false;
 
     for (const auto & kv : modules) {
+        // Cooperative cancel: this is the ~17 s hot loop. Check every iter so
+        // a wrapper-side cancel during cold start aborts in <100 ms instead of
+        // waiting for all 352 deltas to finish.
+        if (adapter_cancel_requested()) {
+            fprintf(stderr, "[Adapter-RT] LoKr: cancelled at delta %d/%zu (merged=%d, skipped=%d)\n",
+                    merged + skipped, modules.size(), merged, skipped);
+            cancelled = true;
+            break;
+        }
+
         const std::string & lyc_prefix = kv.first;
         const LoKrEntry &   m          = kv.second;
 
@@ -506,6 +537,9 @@ static bool adapter_runtime_lokr(DiTLoRA *                  lora,
         merged++;
     }
 
+    if (cancelled) {
+        return false;
+    }
     fprintf(stderr, "[Adapter-RT] LoKr: %d deltas precomputed (%d skipped), scale=%.2f\n",
             merged, skipped, user_scale);
     return merged > 0;

--- a/engine/tools/ace-server.cpp
+++ b/engine/tools/ace-server.cpp
@@ -1671,6 +1671,160 @@ static void handle_vae(const httplib::Request & req, httplib::Response & res) {
     res.set_content(body, "application/json");
 }
 
+// warm worker: same setup as synth_worker through ace_synth_load, then stops.
+// On EVICT_NEVER (set by `?keep_loaded=1` or `--keep-loaded`) the modules
+// stay resident, so the next /synth using the same DiT + adapter combo skips
+// the cold-start load. Returns immediately on STRICT — there's no value in
+// pre-loading under STRICT because the modules would be evicted instantly.
+struct WarmRequest {
+    std::string dit;
+    std::string vae;
+    std::string adapter;
+    float       adapter_scale = 1.0f;
+};
+
+static void warm_worker(std::shared_ptr<Job> job, WarmRequest wr) {
+    if (job->cancel.load()) {
+        job_set_phase(*job, JobPhase::CANCELLED);
+        job->status.store(JobStatus::CANCELLED);
+        return;
+    }
+
+    if (!g_keep_loaded) {
+        // Document the no-op clearly so callers learn from the response.
+        job->result_body = "{\"warm\":false,\"reason\":\"keep_loaded not set; would be evicted immediately\"}";
+        job->result_mime = "application/json";
+        job_set_phase(*job, JobPhase::DONE);
+        job->status.store(JobStatus::DONE);
+        return;
+    }
+
+    std::string        dit_name = resolve_name(g_registry.dit, wr.dit, g_loaded_dit);
+    const ModelEntry * dit      = registry_find(g_registry.dit, dit_name.c_str());
+    if (!dit || g_registry.text_enc.empty() || g_registry.vae.empty()) {
+        fprintf(stderr, "[Server] warm: DiT/Text-Enc/VAE not resolvable\n");
+        job_set_phase(*job, JobPhase::FAILED);
+        job->status.store(JobStatus::FAILED);
+        return;
+    }
+    std::string        vae_name = resolve_name(g_registry.vae, wr.vae, g_loaded_vae);
+    const ModelEntry * vae      = registry_find(g_registry.vae, vae_name.c_str());
+    if (!vae) {
+        fprintf(stderr, "[Server] warm: VAE not found: %s\n", vae_name.c_str());
+        job_set_phase(*job, JobPhase::FAILED);
+        job->status.store(JobStatus::FAILED);
+        return;
+    }
+
+    // Idempotent fast-path: if the same DiT + adapter combo is already in the
+    // sticky-name slot, the store already holds it resident — no work to do.
+    if (g_loaded_dit == dit_name && g_loaded_adapter == wr.adapter && g_loaded_vae == vae_name) {
+        job->result_body = "{\"warm\":true,\"already_loaded\":true}";
+        job->result_mime = "application/json";
+        job_set_phase(*job, JobPhase::DONE);
+        job->status.store(JobStatus::DONE);
+        fprintf(stderr, "[Server] warm: already loaded (DiT=%s VAE=%s Adapter=%s)\n", dit_name.c_str(), vae_name.c_str(),
+                wr.adapter.c_str());
+        return;
+    }
+
+    AceSynthParams p    = g_synth_params;
+    p.text_encoder_path = g_registry.text_enc[0].path.c_str();
+    p.dit_path          = dit->path.c_str();
+    p.vae_path          = vae->path.c_str();
+    p.adapter_path      = nullptr;
+    p.adapter_scale     = 1.0f;
+    if (!wr.adapter.empty()) {
+        const AdapterEntry * adapter = registry_find_adapter(g_registry, wr.adapter.c_str());
+        if (!adapter) {
+            fprintf(stderr, "[Server] warm: adapter not found: %s\n", wr.adapter.c_str());
+            job_set_phase(*job, JobPhase::FAILED);
+            job->status.store(JobStatus::FAILED);
+            return;
+        }
+        p.adapter_path  = adapter->path.c_str();
+        p.adapter_scale = wr.adapter_scale;
+    }
+
+    fprintf(stderr, "[Server] warm: loading DiT=%s VAE=%s%s%s\n", dit_name.c_str(), vae_name.c_str(),
+            wr.adapter.empty() ? "" : " Adapter=", wr.adapter.c_str());
+
+    job_set_phase(*job, wr.adapter.empty() ? JobPhase::LOADING_DIT : JobPhase::ADAPTER_PRECOMPUTE);
+
+    g_adapter_cancel.store(&job->cancel, std::memory_order_release);
+    struct WarmCancelGuard {
+        ~WarmCancelGuard() { g_adapter_cancel.store(nullptr, std::memory_order_release); }
+    } warm_cancel_guard;
+
+    AceSynth * ctx = ace_synth_load(g_store, &p);
+    if (!ctx) {
+        fprintf(stderr, "[Server] warm: synth load failed\n");
+        bool cancelled = job->cancel.load();
+        job_set_phase(*job, cancelled ? JobPhase::CANCELLED : JobPhase::FAILED);
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
+        return;
+    }
+    // Free the ctx but leave the underlying store entries resident — under
+    // EVICT_NEVER the store ignores the refcount drop, so the modules stay
+    // hot for the next /synth.
+    ace_synth_free(ctx);
+
+    // Set the sticky-name hints so resolve_name picks the same models next.
+    g_loaded_dit           = dit_name;
+    g_loaded_adapter       = wr.adapter;
+    g_loaded_adapter_scale = wr.adapter_scale;
+    g_loaded_vae           = vae_name;
+
+    job->result_body = "{\"warm\":true,\"already_loaded\":false}";
+    job->result_mime = "application/json";
+    job_set_phase(*job, JobPhase::DONE);
+    job->status.store(JobStatus::DONE);
+    fprintf(stderr, "[Server] warm: done (DiT=%s VAE=%s Adapter=%s)\n", dit_name.c_str(), vae_name.c_str(),
+            wr.adapter.c_str());
+}
+
+// POST /warm
+// Accepts JSON body { dit, vae?, adapter?, adapter_scale? }. Spawns a
+// background job that loads the requested DiT + VAE + adapter so the
+// next /synth with the same key short-circuits the model load. Returns
+// {"id":"N"} immediately; poll via GET /job?id=N as with /synth.
+static void handle_warm(const httplib::Request & req, httplib::Response & res) {
+    if (g_registry.dit.empty() || g_registry.text_enc.empty() || g_registry.vae.empty()) {
+        json_error(res, 501, "No synth models in registry (need dit + text-encoder + vae)");
+        return;
+    }
+
+    apply_keep_loaded_if_requested(req);
+
+    WarmRequest wr;
+    if (!req.body.empty()) {
+        yyjson_doc *     doc  = yyjson_read(req.body.c_str(), req.body.size(), 0);
+        yyjson_val *     root = doc ? yyjson_doc_get_root(doc) : nullptr;
+        if (!root || !yyjson_is_obj(root)) {
+            if (doc) yyjson_doc_free(doc);
+            json_error(res, 400, "Invalid JSON: expected an object");
+            return;
+        }
+        yyjson_val * v;
+        if ((v = yyjson_obj_get(root, "dit"))     && yyjson_is_str(v)) wr.dit     = yyjson_get_str(v);
+        if ((v = yyjson_obj_get(root, "vae"))     && yyjson_is_str(v)) wr.vae     = yyjson_get_str(v);
+        if ((v = yyjson_obj_get(root, "adapter")) && yyjson_is_str(v)) wr.adapter = yyjson_get_str(v);
+        if ((v = yyjson_obj_get(root, "adapter_scale")) && yyjson_is_num(v)) {
+            wr.adapter_scale = (float) yyjson_get_num(v);
+        }
+        yyjson_doc_free(doc);
+    }
+
+    auto job = job_create();
+    fprintf(stderr, "[Server] Job %s created (warm: dit=%s vae=%s adapter=%s)\n", job->id.c_str(), wr.dit.c_str(),
+            wr.vae.c_str(), wr.adapter.c_str());
+
+    work_push([job, wr]() mutable { warm_worker(job, std::move(wr)); });
+
+    std::string body = "{\"id\":\"" + job->id + "\"}";
+    res.set_content(body, "application/json");
+}
+
 // GET /props
 // server configuration, available models, and default request.
 // the webui reads this at boot to populate dropdowns and status indicators.
@@ -1948,6 +2102,7 @@ int main(int argc, char ** argv) {
     svr.Post("/synth", handle_synth);
     svr.Post("/understand", handle_understand);
     svr.Post("/vae", handle_vae);
+    svr.Post("/warm", handle_warm);
     svr.Get("/health", [](const httplib::Request &, httplib::Response & res) {
         res.set_content("{\"status\":\"ok\"}", "application/json");
     });

--- a/engine/tools/ace-server.cpp
+++ b/engine/tools/ace-server.cpp
@@ -542,6 +542,15 @@ struct LogCapture {
 
 // GET /logs: SSE stream of stderr lines.
 // sends backlog (up to LOG_RING_SIZE) then streams new lines in real time.
+//
+// TODO(2f, engine-cpp-F8): SSE subscribers each pin one worker thread from
+// httplib's shared ThreadPool for the full connection lifetime. With N
+// long-lived SSE clients the pool starves and /job + /synth requests get
+// queued behind them. httplib only exposes a single `new_task_queue`
+// factory (no per-route pool), so segregating /logs needs either a second
+// listener on a different port or a hand-rolled epoll/select dispatcher
+// inside this route — both are deep httplib surgery and out of scope for
+// the wrapper-resilience pass. Left as a follow-up.
 static void handle_logs(const httplib::Request &, httplib::Response & res) {
     res.set_header("Cache-Control", "no-cache");
     res.set_header("X-Accel-Buffering", "no");

--- a/engine/tools/ace-server.cpp
+++ b/engine/tools/ace-server.cpp
@@ -1825,6 +1825,37 @@ static void handle_warm(const httplib::Request & req, httplib::Response & res) {
     res.set_content(body, "application/json");
 }
 
+// GET /jobs
+// Returns an array of every job currently in g_jobs. Lets external
+// reconcilers (e.g. apps/ose/acestep/run.py) discover live engine jobs
+// when the wrapper has died mid-flight. Honors the existing MAX_JOBS
+// eviction policy: evicted jobs are not listed. Read-only — does not
+// touch the worker queue or model store.
+static void handle_jobs_list(const httplib::Request &, httplib::Response & res) {
+    yyjson_mut_doc * doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val * arr = yyjson_mut_arr(doc);
+    yyjson_mut_doc_set_root(doc, arr);
+
+    std::lock_guard<std::mutex> lock(mtx_jobs);
+    for (const auto & id : g_job_order) {
+        auto it = g_jobs.find(id);
+        if (it == g_jobs.end()) continue;
+        const auto & j = it->second;
+        yyjson_mut_val * obj = yyjson_mut_obj(doc);
+        yyjson_mut_obj_add_str(doc, obj, "id", j->id.c_str());
+        yyjson_mut_obj_add_str(doc, obj, "status", job_status_str(j->status.load()));
+        yyjson_mut_obj_add_str(doc, obj, "phase",  job_phase_str(j->phase.load()));
+        yyjson_mut_obj_add_int(doc, obj, "phase_step",  j->phase_step.load(std::memory_order_relaxed));
+        yyjson_mut_obj_add_int(doc, obj, "phase_total", j->phase_total.load(std::memory_order_relaxed));
+        yyjson_mut_arr_append(arr, obj);
+    }
+
+    char * json = yyjson_mut_write(doc, 0, NULL);
+    yyjson_mut_doc_free(doc);
+    res.set_content(json, "application/json");
+    free(json);
+}
+
 // GET /props
 // server configuration, available models, and default request.
 // the webui reads this at boot to populate dropdowns and status indicators.
@@ -2108,6 +2139,7 @@ int main(int argc, char ** argv) {
     });
     svr.Get("/props", handle_props);
     svr.Get("/logs", handle_logs);
+    svr.Get("/jobs", handle_jobs_list);
 
     // job system endpoints
     svr.Get("/job", [](const httplib::Request & req, httplib::Response & res) {

--- a/engine/tools/ace-server.cpp
+++ b/engine/tools/ace-server.cpp
@@ -28,6 +28,7 @@
 //   /synth      DiT + Text-Enc + VAE
 //   /understand LM + DiT + VAE
 
+#include "adapter-cancel.h"   // g_adapter_cancel — set by worker around ace_synth_load
 #include "audio-io.h"
 #include "model-registry.h"
 #include "model-store.h"
@@ -878,13 +879,23 @@ static void synth_worker(std::shared_ptr<Job>    job,
     job_set_phase(*job, ace_reqs[0].adapter.empty() ? JobPhase::LOADING_DIT
                                                     : JobPhase::ADAPTER_PRECOMPUTE);
 
+    // Wire the per-job cancel flag into the adapter precompute loops so a
+    // wrapper-side cancel during cold start aborts in <100 ms instead of
+    // waiting for all 352 deltas to finish. Cleared in a RAII guard below
+    // regardless of which exit path we take.
+    g_adapter_cancel.store(&job->cancel, std::memory_order_release);
+    struct AdapterCancelGuard {
+        ~AdapterCancelGuard() { g_adapter_cancel.store(nullptr, std::memory_order_release); }
+    } adapter_cancel_guard;
+
     AceSynth * ctx = ace_synth_load(g_store, &p);
     if (!ctx) {
         fprintf(stderr, "[Server] FATAL: synth load failed\n");
         free(src_interleaved);
         free(ref_interleaved);
-        job_set_phase(*job, JobPhase::FAILED);
-        job->status.store(JobStatus::FAILED);
+        bool cancelled = job->cancel.load();
+        job_set_phase(*job, cancelled ? JobPhase::CANCELLED : JobPhase::FAILED);
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
         return;
     }
     job_set_phase(*job, JobPhase::DIT_INFERENCE, 0, ace_reqs[0].inference_steps);

--- a/engine/tools/ace-server.cpp
+++ b/engine/tools/ace-server.cpp
@@ -209,6 +209,53 @@ enum class JobStatus : int {
     CANCELLED = 3,
 };
 
+// Fine-grained phase the worker is currently in. Surfaced through GET /job
+// alongside the coarse JobStatus so the wrapper (and any external reconciler
+// hitting :8085 directly, e.g. apps/ose/acestep/run.py) can tell *why* a
+// long-running job is taking a while — model load vs. adapter precompute
+// (the 17 s LoKr stall) vs. actual DiT inference.
+//
+// Phases are advisory: workers may skip ones that don't apply (e.g. /lm
+// never enters DIT_INFERENCE). Order roughly follows the synth pipeline.
+enum class JobPhase : int {
+    QUEUED               = 0,
+    LOADING_TEXT_ENC     = 1,
+    ENCODING_TEXT        = 2,
+    LOADING_COND_ENC     = 3,
+    ENCODING_COND        = 4,
+    LOADING_DIT          = 5,
+    LOADING_ADAPTER      = 6,
+    ADAPTER_PRECOMPUTE   = 7,
+    DIT_INFERENCE        = 8,
+    LOADING_VAE          = 9,
+    VAE_DECODE           = 10,
+    ENCODING_OUTPUT      = 11,
+    DONE                 = 12,
+    FAILED               = 13,
+    CANCELLED            = 14,
+};
+
+static const char * job_phase_str(JobPhase p) {
+    switch (p) {
+        case JobPhase::QUEUED:               return "queued";
+        case JobPhase::LOADING_TEXT_ENC:     return "loading_text_enc";
+        case JobPhase::ENCODING_TEXT:        return "encoding_text";
+        case JobPhase::LOADING_COND_ENC:     return "loading_cond_enc";
+        case JobPhase::ENCODING_COND:        return "encoding_cond";
+        case JobPhase::LOADING_DIT:          return "loading_dit";
+        case JobPhase::LOADING_ADAPTER:      return "loading_adapter";
+        case JobPhase::ADAPTER_PRECOMPUTE:   return "adapter_precompute";
+        case JobPhase::DIT_INFERENCE:        return "dit_inference";
+        case JobPhase::LOADING_VAE:          return "loading_vae";
+        case JobPhase::VAE_DECODE:           return "vae_decode";
+        case JobPhase::ENCODING_OUTPUT:      return "encoding_output";
+        case JobPhase::DONE:                 return "done";
+        case JobPhase::FAILED:               return "failed";
+        case JobPhase::CANCELLED:            return "cancelled";
+    }
+    return "unknown";
+}
+
 struct Job {
     std::string            id;
     std::atomic<JobStatus> status{ JobStatus::RUNNING };
@@ -216,11 +263,28 @@ struct Job {
     std::string            result_mime;
     std::atomic<bool>      cancel{ false };
 
+    // Phase tracking. phase_step / phase_total are optional sub-progress
+    // for phases that have a natural counter (e.g. DIT_INFERENCE: step/total
+    // = current denoise step / inference_steps; ADAPTER_PRECOMPUTE could
+    // count deltas). 0/0 means "no sub-progress available".
+    std::atomic<JobPhase>  phase{ JobPhase::QUEUED };
+    std::atomic<int>       phase_step{ 0 };
+    std::atomic<int>       phase_total{ 0 };
+
     // memory ordering contract: result_body and result_mime are written
     // before status is stored (seq_cst). the client loads status (seq_cst)
     // and only reads result fields after seeing done/failed. this guarantees
     // visibility without an explicit mutex on the result fields.
 };
+
+// Helper: set both phase + reset step counters in one shot. Workers use this
+// at log-anchor points so external observers never see a stale step counter
+// from the previous phase.
+static inline void job_set_phase(Job & job, JobPhase p, int step = 0, int total = 0) {
+    job.phase_step.store(step, std::memory_order_relaxed);
+    job.phase_total.store(total, std::memory_order_relaxed);
+    job.phase.store(p, std::memory_order_release);
+}
 
 static std::mutex                                            mtx_jobs;
 static std::unordered_map<std::string, std::shared_ptr<Job>> g_jobs;
@@ -581,6 +645,7 @@ static std::string resolve_name(const std::vector<ModelEntry> & bucket,
 // LM worker: generates metadata + lyrics + codes, stores JSON result in job.
 static void lm_worker(std::shared_ptr<Job> job, AceRequest ace_req, int lm_batch_size, int mode) {
     if (job->cancel.load()) {
+        job_set_phase(*job, JobPhase::CANCELLED);
         job->status.store(JobStatus::CANCELLED);
         return;
     }
@@ -590,11 +655,17 @@ static void lm_worker(std::shared_ptr<Job> job, AceRequest ace_req, int lm_batch
     const ModelEntry * entry   = registry_find(g_registry.lm, lm_name.c_str());
     if (!entry) {
         fprintf(stderr, "[Server] LM not found: %s\n", lm_name.c_str());
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
     AceLmParams p = g_lm_params;
     p.model_path  = entry->path.c_str();
+
+    // LM has no DiT; it reuses LOADING_DIT to mean "loading the language model
+    // weights" so the wrapper has a single 'loading the big model' phase to
+    // surface, regardless of /lm vs /synth.
+    job_set_phase(*job, JobPhase::LOADING_DIT);
 
     // Acquire a fresh LM ctx from the shared store. Under EVICT_STRICT the
     // module is reloaded if another pipeline evicted it; under EVICT_NEVER
@@ -602,9 +673,11 @@ static void lm_worker(std::shared_ptr<Job> job, AceRequest ace_req, int lm_batch
     AceLm * ctx = ace_lm_load(g_store, &p);
     if (!ctx) {
         fprintf(stderr, "[Server] FATAL: LM load failed\n");
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::DIT_INFERENCE);  // LM "inference" phase
 
     // Execute and always free the ctx, success or failure: the store decides
     // whether the underlying GPU module stays resident.
@@ -614,9 +687,12 @@ static void lm_worker(std::shared_ptr<Job> job, AceRequest ace_req, int lm_batch
     ace_lm_free(ctx);
 
     if (rc != 0) {
-        job->status.store(job->cancel.load() ? JobStatus::CANCELLED : JobStatus::FAILED);
+        bool cancelled = job->cancel.load();
+        job_set_phase(*job, cancelled ? JobPhase::CANCELLED : JobPhase::FAILED);
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::ENCODING_OUTPUT);
 
     // Sticky name hint for resolve_name under --keep-loaded. Master clears it
     // in the default mode since the ctx is gone; we match that behavior.
@@ -638,6 +714,7 @@ static void lm_worker(std::shared_ptr<Job> job, AceRequest ace_req, int lm_batch
 
     job->result_body = std::move(body);
     job->result_mime = "application/json";
+    job_set_phase(*job, JobPhase::DONE);
     job->status.store(JobStatus::DONE);
     fprintf(stderr, "[Server] Job %s done (LM, %d results)\n", job->id.c_str(), lm_batch_size);
 }
@@ -735,6 +812,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
     if (job->cancel.load()) {
         free(src_interleaved);
         free(ref_interleaved);
+        job_set_phase(*job, JobPhase::CANCELLED);
         job->status.store(JobStatus::CANCELLED);
         return;
     }
@@ -746,6 +824,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
         fprintf(stderr, "[Server] DiT not found: %s\n", dit_name.c_str());
         free(src_interleaved);
         free(ref_interleaved);
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
@@ -753,6 +832,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
         fprintf(stderr, "[Server] Missing Text-Enc or VAE in registry\n");
         free(src_interleaved);
         free(ref_interleaved);
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
@@ -762,6 +842,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
         fprintf(stderr, "[Server] VAE not found: %s\n", vae_name.c_str());
         free(src_interleaved);
         free(ref_interleaved);
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
@@ -778,6 +859,7 @@ static void synth_worker(std::shared_ptr<Job>    job,
             fprintf(stderr, "[Server] Adapter not found: %s\n", ace_reqs[0].adapter.c_str());
             free(src_interleaved);
             free(ref_interleaved);
+            job_set_phase(*job, JobPhase::FAILED);
             job->status.store(JobStatus::FAILED);
             return;
         }
@@ -787,14 +869,25 @@ static void synth_worker(std::shared_ptr<Job>    job,
     fprintf(stderr, "[Server] Loading synth: DiT=%s VAE=%s%s%s\n", dit_name.c_str(), vae_name.c_str(),
             ace_reqs[0].adapter.empty() ? "" : " Adapter=", ace_reqs[0].adapter.c_str());
 
+    // ace_synth_load fans out into text-enc + cond-enc + DiT + adapter (LoKr
+    // precompute) + VAE setup, all serialized. We don't have per-sub-load
+    // callbacks here, so we mark the whole call as the heaviest phase:
+    // ADAPTER_PRECOMPUTE when an adapter is in play (the 17 s stall), else
+    // LOADING_DIT. The wrapper / run.py reconcile path keys on this to
+    // explain why a job is silent for 15+ seconds with no DiT step logs yet.
+    job_set_phase(*job, ace_reqs[0].adapter.empty() ? JobPhase::LOADING_DIT
+                                                    : JobPhase::ADAPTER_PRECOMPUTE);
+
     AceSynth * ctx = ace_synth_load(g_store, &p);
     if (!ctx) {
         fprintf(stderr, "[Server] FATAL: synth load failed\n");
         free(src_interleaved);
         free(ref_interleaved);
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::DIT_INFERENCE, 0, ace_reqs[0].inference_steps);
 
     // Build the flat batch. Seeds are resolved per original request, then
     // synth_batch_size is expanded into per-seed variants in groups[0].
@@ -848,9 +941,15 @@ static void synth_worker(std::shared_ptr<Job>    job,
         for (auto & a : audio) {
             ace_audio_free(&a);
         }
-        job->status.store(job->cancel.load() ? JobStatus::CANCELLED : JobStatus::FAILED);
+        bool cancelled = job->cancel.load();
+        job_set_phase(*job, cancelled ? JobPhase::CANCELLED : JobPhase::FAILED);
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
         return;
     }
+
+    // After synth_batch_run returns, the audio is decoded — the VAE pass is
+    // included inside the runner. Surface the wav/mp3 encode phase next.
+    job_set_phase(*job, JobPhase::ENCODING_OUTPUT, 0, total_alloc);
 
     // Sticky name hints for resolve_name under --keep-loaded. Master clears
     // them in the default mode since the ctx is gone; we match that behavior.
@@ -895,7 +994,9 @@ static void synth_worker(std::shared_ptr<Job>    job,
     job->result_body = multipart_build_audio_latent(encoded, mime, captured_latents);
     job->result_mime = MULTIPART_MIME;
 
-    job->status.store(job->cancel.load() ? JobStatus::CANCELLED : JobStatus::DONE);
+    bool cancelled = job->cancel.load();
+    job_set_phase(*job, cancelled ? JobPhase::CANCELLED : JobPhase::DONE);
+    job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::DONE);
     fprintf(stderr, "[Server] Job %s done (%d tracks)\n", job->id.c_str(), total_tracks);
 }
 
@@ -1086,6 +1187,7 @@ static void understand_worker(std::shared_ptr<Job> job,
                               int                  src_T_latent) {
     if (job->cancel.load()) {
         free(src_interleaved);
+        job_set_phase(*job, JobPhase::CANCELLED);
         job->status.store(JobStatus::CANCELLED);
         return;
     }
@@ -1101,6 +1203,7 @@ static void understand_worker(std::shared_ptr<Job> job,
         fprintf(stderr, "[Server] LM, DiT or VAE not found: lm=%s dit=%s vae=%s\n", lm_name.c_str(), dit_name.c_str(),
                 vae_name.c_str());
         free(src_interleaved);
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
@@ -1110,13 +1213,16 @@ static void understand_worker(std::shared_ptr<Job> job,
     p.dit_path            = dit->path.c_str();
     p.vae_path            = vae_entry->path.c_str();
 
+    job_set_phase(*job, JobPhase::LOADING_DIT);
     AceUnderstand * ctx = ace_understand_load(g_store, &p);
     if (!ctx) {
         fprintf(stderr, "[Server] FATAL: understand load failed\n");
         free(src_interleaved);
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::DIT_INFERENCE);
 
     AceRequest         out;
     std::vector<float> captured_latent;
@@ -1128,9 +1234,12 @@ static void understand_worker(std::shared_ptr<Job> job,
     free(src_interleaved);
 
     if (rc != 0) {
-        job->status.store(job->cancel.load() ? JobStatus::CANCELLED : JobStatus::FAILED);
+        bool cancelled = job->cancel.load();
+        job_set_phase(*job, cancelled ? JobPhase::CANCELLED : JobPhase::FAILED);
+        job->status.store(cancelled ? JobStatus::CANCELLED : JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::ENCODING_OUTPUT);
 
     // Sticky name hints for resolve_name under --keep-loaded. Master clears
     // them in the default mode since the ctx is gone; we match that behavior.
@@ -1147,6 +1256,7 @@ static void understand_worker(std::shared_ptr<Job> job,
     std::string json_part = "[" + request_to_json(&out) + "]";
     job->result_body      = multipart_build_json_latent(json_part, captured_latent, captured_T_latent);
     job->result_mime      = MULTIPART_MIME;
+    job_set_phase(*job, JobPhase::DONE);
     job->status.store(JobStatus::DONE);
     fprintf(stderr, "[Server] Job %s done (understand)\n", job->id.c_str());
 }
@@ -1263,6 +1373,7 @@ static void decode_worker(std::shared_ptr<Job> job,
                           WavFormat            wav_fmt,
                           int                  peak_clip) {
     if (job->cancel.load()) {
+        job_set_phase(*job, JobPhase::CANCELLED);
         job->status.store(JobStatus::CANCELLED);
         return;
     }
@@ -1271,6 +1382,7 @@ static void decode_worker(std::shared_ptr<Job> job,
     const ModelEntry * vae_entry = registry_find(g_registry.vae, vae_name.c_str());
     if (!vae_entry) {
         fprintf(stderr, "[Server] decode: VAE not found: %s\n", vae_name.c_str());
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
@@ -1280,13 +1392,16 @@ static void decode_worker(std::shared_ptr<Job> job,
     vae_key.path          = vae_entry->path;
     vae_key.adapter_scale = 1.0f;
 
+    job_set_phase(*job, JobPhase::LOADING_VAE);
     Timer     t_dec;
     VAEGGML * vae = store_require_vae_dec(g_store, vae_key);
     if (!vae) {
         fprintf(stderr, "[Server] decode: store_require_vae_dec failed\n");
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::VAE_DECODE);
     ModelHandle vae_guard(g_store, vae);
 
     int                T_audio_max = (src_T_latent + 64) * 1920;
@@ -1295,9 +1410,11 @@ static void decode_worker(std::shared_ptr<Job> job,
                                         g_synth_params.vae_chunk, g_synth_params.vae_overlap);
     if (T_audio < 0) {
         fprintf(stderr, "[Server] decode: vae_ggml_decode_tiled failed\n");
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::ENCODING_OUTPUT);
     fprintf(stderr, "[Server] decode: %d latent frames -> %d audio samples (%.2fs), %.0fms\n", src_T_latent, T_audio,
             (float) T_audio / 48000.0f, t_dec.ms());
 
@@ -1326,7 +1443,9 @@ static void decode_worker(std::shared_ptr<Job> job,
     // client just uploaded it, echoing it back would only burn bandwidth.
     job->result_body = std::move(encoded);
     job->result_mime = mime;
-    job->status.store(job->cancel.load() ? JobStatus::CANCELLED : JobStatus::DONE);
+    bool decode_cancelled = job->cancel.load();
+    job_set_phase(*job, decode_cancelled ? JobPhase::CANCELLED : JobPhase::DONE);
+    job->status.store(decode_cancelled ? JobStatus::CANCELLED : JobStatus::DONE);
     fprintf(stderr, "[Server] Job %s done (decode)\n", job->id.c_str());
 }
 
@@ -1347,6 +1466,7 @@ static void encode_worker(std::shared_ptr<Job> job, AceRequest ace_req, float * 
     } buf{ src_interleaved };
 
     if (job->cancel.load()) {
+        job_set_phase(*job, JobPhase::CANCELLED);
         job->status.store(JobStatus::CANCELLED);
         return;
     }
@@ -1355,6 +1475,7 @@ static void encode_worker(std::shared_ptr<Job> job, AceRequest ace_req, float * 
     const ModelEntry * vae_entry = registry_find(g_registry.vae, vae_name.c_str());
     if (!vae_entry) {
         fprintf(stderr, "[Server] encode: VAE not found: %s\n", vae_name.c_str());
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
@@ -1364,13 +1485,16 @@ static void encode_worker(std::shared_ptr<Job> job, AceRequest ace_req, float * 
     vae_key.path          = vae_entry->path;
     vae_key.adapter_scale = 1.0f;
 
+    job_set_phase(*job, JobPhase::LOADING_VAE);
     Timer        t_enc;
     VAEEncoder * vae = store_require_vae_enc(g_store, vae_key);
     if (!vae) {
         fprintf(stderr, "[Server] encode: store_require_vae_enc failed\n");
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::VAE_DECODE);  // encoder runs the same VAE codec, reuse phase
     ModelHandle vae_guard(g_store, vae);
 
     // 1 latent frame covers 1920 audio samples, plus a safety tile for the
@@ -1385,9 +1509,11 @@ static void encode_worker(std::shared_ptr<Job> job, AceRequest ace_req, float * 
                                                        g_synth_params.vae_chunk, g_synth_params.vae_overlap);
     if (T_latent < 0) {
         fprintf(stderr, "[Server] encode: vae_enc_encode_tiled failed\n");
+        job_set_phase(*job, JobPhase::FAILED);
         job->status.store(JobStatus::FAILED);
         return;
     }
+    job_set_phase(*job, JobPhase::ENCODING_OUTPUT);
     fprintf(stderr, "[Server] encode: %d audio samples (%.2fs) -> %d latent frames, %.0fms\n", src_len,
             (float) src_len / 48000.0f, T_latent, t_enc.ms());
 
@@ -1405,7 +1531,9 @@ static void encode_worker(std::shared_ptr<Job> job, AceRequest ace_req, float * 
     std::memcpy(body.data(), latent.data(), body.size());
     job->result_body = std::move(body);
     job->result_mime = "application/octet-stream";
-    job->status.store(job->cancel.load() ? JobStatus::CANCELLED : JobStatus::DONE);
+    bool encode_cancelled = job->cancel.load();
+    job_set_phase(*job, encode_cancelled ? JobPhase::CANCELLED : JobPhase::DONE);
+    job->status.store(encode_cancelled ? JobStatus::CANCELLED : JobStatus::DONE);
     fprintf(stderr, "[Server] Job %s done (encode)\n", job->id.c_str());
 }
 
@@ -1835,11 +1963,17 @@ int main(int argc, char ** argv) {
             res.set_content(job->result_body, job->result_mime);
             return;
         }
-        // default: return status JSON
-        std::string body = "{\"status\":\"";
-        body += job_status_str(job->status.load());
-        body += "\"}";
-        res.set_content(body, "application/json");
+        // default: return status JSON. Now includes phase + phase_step/total
+        // so the wrapper (and external reconcilers like apps/ose/acestep/run.py)
+        // can distinguish "stalled in 17 s adapter precompute" from "actually
+        // failed" without parsing /logs SSE.
+        char phase_buf[256];
+        int  step  = job->phase_step.load(std::memory_order_relaxed);
+        int  total = job->phase_total.load(std::memory_order_relaxed);
+        snprintf(phase_buf, sizeof(phase_buf),
+                 "{\"status\":\"%s\",\"phase\":\"%s\",\"phase_step\":%d,\"phase_total\":%d}",
+                 job_status_str(job->status.load()), job_phase_str(job->phase.load()), step, total);
+        res.set_content(phase_buf, "application/json");
     });
     svr.Post("/job", [](const httplib::Request & req, httplib::Response & res) {
         if (!req.has_param("id")) {

--- a/engine/tools/ace-server.cpp
+++ b/engine/tools/ace-server.cpp
@@ -530,6 +530,38 @@ static void json_error(httplib::Response & res, int status, const char * msg) {
     free(json);
 }
 
+// Per-request `?keep_loaded=1` (or `keep_loaded=true`) flips the server into
+// EVICT_NEVER for the rest of its lifetime. Idempotent: if the server is
+// already keep-loaded (CLI flag or an earlier request), this is a no-op.
+//
+// This is the wrapper-facing knob for the cold-start LoKr precompute stall
+// (Jun 6 incident). The Node wrapper already passes a `keepLoaded` boolean
+// to aceClient.submitLm / submitSynth; before this hook the engine ignored
+// it, so every request paid the ~17 s adapter precompute cost. With the
+// per-request flag honored, the second /synth with the same DiT + adapter
+// short-circuits the load via the ModelStore cache.
+static bool request_keep_loaded(const httplib::Request & req) {
+    if (!req.has_param("keep_loaded")) {
+        return false;
+    }
+    const std::string & v = req.get_param_value("keep_loaded");
+    return v == "1" || v == "true";
+}
+
+static void apply_keep_loaded_if_requested(const httplib::Request & req) {
+    if (g_keep_loaded) {
+        return;  // already on, no work to do
+    }
+    if (!request_keep_loaded(req)) {
+        return;
+    }
+    g_keep_loaded = true;
+    if (g_store) {
+        store_set_policy(g_store, EVICT_NEVER);
+    }
+    fprintf(stderr, "[Server] keep_loaded enabled via request query param\n");
+}
+
 // resolve model name: explicit request > already loaded > first in bucket
 static std::string resolve_name(const std::vector<ModelEntry> & bucket,
                                 const std::string &             requested,
@@ -623,6 +655,10 @@ static void handle_lm(const httplib::Request & req, httplib::Response & res) {
         json_error(res, 501, "No LM models in registry");
         return;
     }
+
+    // honor `?keep_loaded=1` from the wrapper — keeps the LM resident across
+    // requests so the next /lm call short-circuits the model load.
+    apply_keep_loaded_if_requested(req);
 
     // parse request
     AceRequest ace_req;
@@ -886,6 +922,11 @@ static void handle_synth(const httplib::Request & req, httplib::Response & res) 
         return;
     }
 
+    // honor `?keep_loaded=1` — primary reason this knob exists: keep DiT +
+    // adapter (with its 17 s precomputed LoKr deltas) resident across /synth
+    // requests so the cold-start path only ever runs once.
+    apply_keep_loaded_if_requested(req);
+
     // parse request: plain JSON (single or array) or multipart (JSON + audio file or src_latents).
     // synth_model, lm_model, adapter, adapter_scale travel inside AceRequest now.
     std::vector<AceRequest> ace_reqs;
@@ -1127,6 +1168,8 @@ static void handle_understand(const httplib::Request & req, httplib::Response & 
         json_error(res, 400, "Understand requires multipart/form-data");
         return;
     }
+
+    apply_keep_loaded_if_requested(req);
 
     // parse multipart: required "audio" or "src_latents" part, optional "request" part for sampling params.
     // synth_model, lm_model, adapter, adapter_scale travel inside AceRequest.
@@ -1388,6 +1431,8 @@ static void handle_vae(const httplib::Request & req, httplib::Response & res) {
         json_error(res, 400, "VAE endpoint requires multipart/form-data");
         return;
     }
+
+    apply_keep_loaded_if_requested(req);
 
     AceRequest ace_req;
     request_init(&ace_req);

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -127,6 +127,26 @@ export const config = {
      *  with ACESTEPCPP_KEEP_LOADED=0 if VRAM is tight and you'd rather
      *  pay the cold-start cost than carry several DiT+adapter combos. */
     keepLoaded: (process.env.ACESTEPCPP_KEEP_LOADED ?? '1') !== '0',
+    /** Post /warm to the engine after it boots, pre-loading the configured
+     *  DiT + VAE + adapter so the first user-facing /synth skips the ~7 min
+     *  cold-start VRAM-copy phase. Requires keepLoaded — under EVICT_STRICT
+     *  the engine drops the modules instantly, making the warm a waste.
+     *  Default '1' when keepLoaded is on; set ACESTEPCPP_WARM_ON_STARTUP=0
+     *  to disable. */
+    warmOnStartup: (process.env.ACESTEPCPP_WARM_ON_STARTUP ?? '1') !== '0',
+    /** Filename of the DiT to warm (resolved against models dir).
+     *  Falls back to ACESTEP_DIT_MODEL (the worker hotstep.conf knob) so
+     *  the warm naturally matches what the worker submits. */
+    warmDit: process.env.ACESTEPCPP_WARM_DIT || process.env.ACESTEP_DIT_MODEL || '',
+    /** Filename of the VAE to warm. */
+    warmVae: process.env.ACESTEPCPP_WARM_VAE || process.env.ACESTEP_VAE_MODEL || '',
+    /** Filename of the adapter to warm (resolved against adapters dir).
+     *  Empty disables adapter pre-load — DiT/VAE alone still cuts most of
+     *  the cold-start. */
+    warmAdapter: process.env.ACESTEPCPP_WARM_ADAPTER || '',
+    /** Adapter scale to use for the warm. Matches ACESTEP_LORA_SCALE default
+     *  so the warm and the worker hit the same LoKr-delta cache key. */
+    warmAdapterScale: parseFloat(process.env.ACESTEPCPP_WARM_ADAPTER_SCALE || process.env.ACESTEP_LORA_SCALE || '0.97'),
     /** TensorRT runtime DLL directory — auto-detected or TENSORRT_LIBS env override */
     trtLibs: process.env.TENSORRT_LIBS || (() => {
       // Auto-detect from engine/deps/tensorrt_libs/ (downloaded by Model Manager)

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -119,6 +119,14 @@ export const config = {
     // To re-enable: set ACESTEPCPP_DRAFT_LM env var or uncomment auto-detect.
     draftLm: process.env.ACESTEPCPP_DRAFT_LM || '',
     onnxDir: process.env.ACESTEPCPP_ONNX_DIR || DEFAULT_ONNX_DIR,
+    /** Pass --keep-loaded to the spawned ace-server, flipping the engine's
+     *  ModelStore to EVICT_NEVER at startup so DiT + adapter + LoKr
+     *  precompute stay resident across requests. Default true: the cold-
+     *  start LoKr precompute is ~17 s, hot-start ~50 ms — keeping models
+     *  loaded is the right default for an interactive product. Override
+     *  with ACESTEPCPP_KEEP_LOADED=0 if VRAM is tight and you'd rather
+     *  pay the cold-start cost than carry several DiT+adapter combos. */
+    keepLoaded: (process.env.ACESTEPCPP_KEEP_LOADED ?? '1') !== '0',
     /** TensorRT runtime DLL directory — auto-detected or TENSORRT_LIBS env override */
     trtLibs: process.env.TENSORRT_LIBS || (() => {
       // Auto-detect from engine/deps/tensorrt_libs/ (downloaded by Model Manager)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -169,6 +169,15 @@ function startAceServer(): ChildProcess | null {
     args.push('--adapters', config.aceServer.adapters);
   }
 
+  // --keep-loaded: flips the engine's ModelStore to EVICT_NEVER so the
+  // 17 s LoKr precompute only happens once per DiT + adapter combo. Without
+  // this flag every /synth pays the cold-start cost. Set
+  // ACESTEPCPP_KEEP_LOADED=0 to disable (VRAM-constrained dev boxes).
+  if (config.aceServer.keepLoaded) {
+    args.push('--keep-loaded');
+    console.log('[Server] --keep-loaded: DiT + adapter stay resident across requests');
+  }
+
   // Add noise profile if available
   if (config.aceServer.noiseProfile && fs.existsSync(config.aceServer.noiseProfile)) {
     args.push('--noise-profile', config.aceServer.noiseProfile);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -143,6 +143,7 @@ if (fs.existsSync(uiDistPath)) {
 let aceProcess: ChildProcess | null = null;
 
 import { setEngineReady } from './engineState.js';
+import { aceClient } from './services/aceClient.js';
 
 // Crash-count limiter: prevent infinite respawn on fatal errors (missing DLLs, etc.)
 let crashCount = 0;
@@ -458,7 +459,54 @@ async function ensureRequiredRuntime(): Promise<{ ok: boolean; missing: string[]
   setEngineReady(false, cudaReady ? 'Starting engine...' : 'Starting engine (CPU only — CUDA runtime missing)...');
   aceProcess = startAceServer();
   setEngineReady(true, cudaReady ? 'Ready' : 'Ready (CPU only — GPU runtime missing)');
+
+  // Fire-and-forget: wait for engine /health, then POST /warm with the
+  // configured DiT + VAE + adapter so the first user-facing /synth skips
+  // the ~7-minute cold-start VRAM-copy phase. Failures here only log —
+  // they never block the wrapper from accepting requests.
+  if (config.aceServer.warmOnStartup && config.aceServer.keepLoaded && config.aceServer.warmDit) {
+    void warmEngineOnStartup();
+  } else if (config.aceServer.warmOnStartup && !config.aceServer.keepLoaded) {
+    console.log('[Server] warm-on-startup skipped: ACESTEPCPP_KEEP_LOADED is off (engine would evict immediately)');
+  } else if (config.aceServer.warmOnStartup && !config.aceServer.warmDit) {
+    console.log('[Server] warm-on-startup skipped: no ACESTEPCPP_WARM_DIT or ACESTEP_DIT_MODEL configured');
+  }
 })();
+
+/** Poll engine /health until reachable (or 90s elapsed), then POST /warm
+ *  with the configured DiT + VAE + adapter. The warm is itself an async
+ *  engine job; we kick it off and don't await it, so the wrapper is free
+ *  to accept requests while the LoKr deltas are still being copied to VRAM.
+ *  Any /synth that arrives mid-warm will queue behind it and get the same
+ *  hot cache for free. */
+async function warmEngineOnStartup(): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  let healthy = false;
+  while (Date.now() < deadline) {
+    if (await aceClient.isReachable()) { healthy = true; break; }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  if (!healthy) {
+    console.warn('[Server] warm-on-startup: engine /health never came up in 90s — skipping warm');
+    return;
+  }
+  const cfg = config.aceServer;
+  const req: { dit: string; vae?: string; adapter?: string; adapter_scale?: number } = {
+    dit: cfg.warmDit,
+  };
+  if (cfg.warmVae) req.vae = cfg.warmVae;
+  if (cfg.warmAdapter) {
+    req.adapter = cfg.warmAdapter;
+    if (Number.isFinite(cfg.warmAdapterScale)) req.adapter_scale = cfg.warmAdapterScale;
+  }
+  try {
+    const jobId = await aceClient.warm(req, true);
+    console.log(`[Server] warm-on-startup: posted /warm dit=${cfg.warmDit}${cfg.warmAdapter ? ` adapter=${cfg.warmAdapter}` : ''} job=${jobId}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[Server] warm-on-startup: /warm failed (will warm on first user request instead): ${msg}`);
+  }
+}
 
 // Start Express server
 const server = app.listen(config.server.port, config.server.host, () => {

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -1290,6 +1290,9 @@ router.get('/status/:id', (req, res) => {
     progress: job.progress,
     result: job.result,
     error: job.error,
+    ace_job_id: job.aceJobId ?? null,
+    ace_phase: (job as any).acePhase ?? null,
+    ace_phase_progress: (job as any).acePhaseProgress ?? null,
   });
 });
 

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -44,6 +44,14 @@ interface GenerationJob {
   stage?: string;
   progress?: number;
   aceJobId?: string;  // Current ace-server job ID (LM or synth)
+  /** Fine-grained engine phase pulled from GET /job?id=N (engine commit
+   *  6d9873c). Surfaces "stuck in 17 s adapter precompute" vs. "actually
+   *  failed" so the consumer (Studio UI + apps/ose/acestep/run.py reconcile
+   *  path) can decide whether to keep waiting or bail. */
+  acePhase?: string;
+  /** Sub-phase progress, formatted by pollUntilDone: e.g. "step 12/50" or
+   *  empty when phase_total is 0. Surfaced to /status as ace_phase_progress. */
+  acePhaseProgress?: string;
   lmResults?: AceRequest[];
   result?: {
     audioUrls: string[];
@@ -126,6 +134,16 @@ async function pollUntilDone(aceJobId: string, job: GenerationJob, signal: Abort
     // (e.g. ace-server busy mid-DiT-step) don't kill the loop
     try {
       const status = await aceClient.pollJob(aceJobId);
+      // Surface the engine's fine-grained phase + step counter to the
+      // wrapper Job so /api/generate/status/:id can return them via
+      // ace_phase / ace_phase_progress. The fields are optional on the
+      // wire (old ace-server builds don't populate them), so guard each.
+      if (status.phase) {
+        job.acePhase = status.phase;
+        const step = status.phase_step ?? 0;
+        const total = status.phase_total ?? 0;
+        job.acePhaseProgress = total > 0 ? `step ${step}/${total}` : '';
+      }
       if (status.status === 'done') return;
       if (status.status === 'failed') throw new Error('Generation failed on ace-server');
       if (status.status === 'cancelled') throw new Error('Cancelled by ace-server');
@@ -1291,8 +1309,8 @@ router.get('/status/:id', (req, res) => {
     result: job.result,
     error: job.error,
     ace_job_id: job.aceJobId ?? null,
-    ace_phase: (job as any).acePhase ?? null,
-    ace_phase_progress: (job as any).acePhaseProgress ?? null,
+    ace_phase: job.acePhase ?? null,
+    ace_phase_progress: job.acePhaseProgress ?? null,
   });
 });
 

--- a/server/src/routes/inspire.ts
+++ b/server/src/routes/inspire.ts
@@ -201,6 +201,9 @@ router.get('/status/:id', (req, res) => {
     progress: job.progress,
     result: job.result,
     error: job.error,
+    ace_job_id: job.aceJobId ?? null,
+    ace_phase: (job as any).acePhase ?? null,
+    ace_phase_progress: (job as any).acePhaseProgress ?? null,
   });
 });
 

--- a/server/src/services/aceClient.ts
+++ b/server/src/services/aceClient.ts
@@ -123,6 +123,49 @@ export interface AceRequest {
 /** Job status from ace-server */
 export interface AceJobStatus {
   status: 'running' | 'done' | 'failed' | 'cancelled';
+  /** Fine-grained engine phase (engine commit 6d9873c). Optional for
+   *  back-compat with older ace-server builds. */
+  phase?: AceJobPhase;
+  phase_step?: number;
+  phase_total?: number;
+}
+
+/** Fine-grained engine phase — matches JobPhase in engine/tools/ace-server.cpp.
+ *  Lowercase snake_case mirrors job_phase_str(). */
+export type AceJobPhase =
+  | 'queued'
+  | 'loading_text_enc'
+  | 'encoding_text'
+  | 'loading_cond_enc'
+  | 'encoding_cond'
+  | 'loading_dit'
+  | 'loading_adapter'
+  | 'adapter_precompute'
+  | 'dit_inference'
+  | 'loading_vae'
+  | 'vae_decode'
+  | 'encoding_output'
+  | 'done'
+  | 'failed'
+  | 'cancelled';
+
+/** One row from GET /jobs (engine commit 69db1ab). */
+export interface AceJobsListEntry {
+  id: string;
+  status: 'running' | 'done' | 'failed' | 'cancelled';
+  phase: AceJobPhase;
+  phase_step: number;
+  phase_total: number;
+}
+
+/** Body shape for POST /warm (engine commit 0f31401). */
+export interface AceWarmRequest {
+  dit: string;
+  vae?: string;
+  adapter?: string;
+  adapter_scale?: number;
+  adapter_mode?: string;
+  adapter_group_scales?: AceRequest['adapter_group_scales'];
 }
 
 /** Plugin parameter schema from Lua plugin metadata */
@@ -383,6 +426,30 @@ export const aceClient = {
       method: 'POST',
       signal: AbortSignal.timeout(TIMEOUT_POLL),
     });
+  },
+
+  /** POST /warm — pre-load a DiT + VAE + adapter combo so the next /synth
+   *  with the same key short-circuits the 17 s cold-start adapter precompute.
+   *  Requires the engine to be running in keep-loaded mode (either started
+   *  with --keep-loaded or a prior request set ?keep_loaded=1); under STRICT
+   *  the engine returns {warm:false} since modules would be evicted instantly.
+   *  Returns the engine job id — poll via pollJob until status=done. */
+  async warm(request: AceWarmRequest, keepLoaded = true): Promise<string> {
+    const params = new URLSearchParams();
+    if (keepLoaded) params.set('keep_loaded', '1');
+    const qs = params.toString();
+    const path = qs ? `/warm?${qs}` : '/warm';
+    const res = await acePost(path, request);
+    const data = await res.json() as { id: string };
+    return data.id;
+  },
+
+  /** GET /jobs — enumerate every job currently in the engine's in-memory job
+   *  table. Used by the reconcile path in apps/ose/acestep/run.py to find a
+   *  still-running engine job after the wrapper crashed mid-poll. */
+  async listJobs(): Promise<AceJobsListEntry[]> {
+    const res = await aceGet('/jobs');
+    return res.json();
   },
 
   /** Check if ace-server is reachable */


### PR DESCRIPTION
## Summary
Twelve commits that make the cold-start LoKr precompute a one-time cost rather than a per-render one, plus engine-side observability (JobPhase, /jobs enumeration) and a wrapper-side warm-on-startup that posts /warm after the engine comes up.

## Deployment validation
Validated on an A10G inference EC2 today after restarting the wrapper with these commits:
- Render #1 (cold-start): ~11 min wall-clock
- Render #2 (same DiT + LoKr, --keep-loaded hot cache): **80 s wall-clock**

~8x speedup. ModelStore policy=NEVER keeps the 13.4 GB DiT+adapter+VAE resident; subsequent /synth with the same key skips the entire LoKr precompute + VRAM-copy phase.

## Known caveat — needs follow-up before merge
Three of the engine commits (de1be40 /synth /lm ?keep_loaded=1, 0f31401 POST /warm, a084a08 cancellable precompute) edited `engine/tools/ace-server.cpp`, but the ace-server target is built from `engine/tools/hot-step-server.cpp`. So on the deployed binary today:
- ✅ `--keep-loaded` CLI flag works (pre-existing in hot-step-server.cpp) — this is the source of the 8x speedup
- ❌ `/warm` returns 404, per-request `?keep_loaded=1` is a no-op

These three commits' changes should be ported to `engine/tools/hot-step-server.cpp` before merge. Wrapper warm-on-startup gracefully 404-falls-through today (\`(will warm on first user request instead)\`).

## Commits
- feat(engine): sideband / cancellable LoKr precompute / JobPhase / /jobs (a084a08, 6d9873c, 69db1ab)
- feat(engine): POST /warm endpoint (0f31401) — needs port
- feat(engine): per-request ?keep_loaded=1 honor on /synth /lm /understand /vae (de1be40) — needs port
- feat(wrapper): ACESTEPCPP_KEEP_LOADED env (default '1'), aceClient.warm/listJobs, JobPhase typed surface, generate.ts copies phase to job (97d01ed)
- feat(wrapper): warm-on-startup pre-loads DiT + adapter after engine /health (425a678)
- docs: progress logs for C1/C2/C3 work (218c562, 85fb945, c7931cc)

## Test plan
- [x] `npx tsc --noEmit` in server/ — same 4 pre-existing `findLast` errors, zero new errors
- [x] hotstep-server.service restart picks up `--keep-loaded`: ace-server boot log shows `[Store] Created (policy=NEVER)`
- [x] Two back-to-back A10 renders measured 11 min vs 80 s
- [ ] After /warm port to hot-step-server.cpp: confirm wrapper boot log shows `warm-on-startup: posted /warm dit=... adapter=...` instead of the 404 fallthrough
- [ ] After port: confirm render #1 after restart is also fast (warm hits before user submission)

## Branch state
12 ahead of master, ~39 behind. Conflict-likely with `feat: llama.cpp as first-class LLM provider`, `feat: GPU device selection`, `feat: configurable generation timeout` — those touched `server/src/config.ts` and `server/src/index.ts` near where this branch adds wrapper config + warm-on-startup. Happy to rebase if useful.