### PR TITLE
Separate DiT & LM seeds and fixed seed display

### DIFF
--- a/engine/tools/hot-step-server.cpp
+++ b/engine/tools/hot-step-server.cpp
@@ -837,8 +837,16 @@ static void lm_worker(std::shared_ptr<Job> job, AceRequest ace_req, int lm_batch
 
     // Execute and always free the ctx, success or failure: the store decides
     // whether the underlying GPU module stays resident.
-    // Tie LM seed to DiT seed: locked seed → both deterministic, random → both random.
-    ace_req.lm_seed = ace_req.seed;
+    // Default lm_seed to the DiT seed only when the caller didn't send an
+    // independent one (request_parse_json leaves it at the -1 sentinel when
+    // the "lm_seed" key is absent from the JSON body). This preserves the
+    // old single-seed behavior for clients that only send "seed" (locked
+    // seed -> both deterministic, random -> both random), while letting a
+    // client that explicitly sends "lm_seed" (e.g. a UI with independent
+    // LM/generation seed controls) take priority.
+    if (ace_req.lm_seed < 0) {
+        ace_req.lm_seed = ace_req.seed;
+    }
     request_resolve_lm_seed(&ace_req);
     std::vector<AceRequest> out(lm_batch_size);
     int rc = ace_lm_generate(ctx, &ace_req, lm_batch_size, out.data(), NULL, NULL, server_cancel_job,

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -190,13 +190,21 @@ async function runGeneration(job: GenerationJob): Promise<void> {
 
   const aceReq = translateParams(job.params);
 
-  // Write the resolved seed back into job.params so the DB stores the actual
-  // seed used — critical for reproducibility when randomSeed is true.
+  // Write the resolved seeds back into job.params so the DB stores the actual
+  // values used — critical for reproducibility when randomSeed is true, or
+  // when lmSeedFollowsDit is on (lm_seed isn't sent to the engine at all in
+  // that case — the engine ties it to seed itself — so mirror that here
+  // rather than leaving a stale/unused "fixed" value in job.params).
   if (aceReq.seed !== undefined) {
     job.params.seed = aceReq.seed;
   }
+  if (aceReq.lm_seed !== undefined) {
+    job.params.lmSeed = aceReq.lm_seed;
+  } else if (job.params.lmSeedFollowsDit !== false) {
+    job.params.lmSeed = aceReq.seed;
+  }
 
-  console.log(`[Generate] Job ${job.id} — ditModel=${job.params.ditModel || '(none)'}, synth_model=${aceReq.synth_model || '(none)'}, emb_model=${aceReq.emb_model || '(auto)'}, seed=${aceReq.seed ?? '(engine default)'}, source=${job.params.source || 'create'}`);
+  console.log(`[Generate] Job ${job.id} — ditModel=${job.params.ditModel || '(none)'}, synth_model=${aceReq.synth_model || '(none)'}, emb_model=${aceReq.emb_model || '(auto)'}, seed=${aceReq.seed ?? '(engine default)'}, lm_seed=${aceReq.lm_seed ?? `(tied to seed: ${aceReq.seed ?? 'engine default'})`}, source=${job.params.source || 'create'}`);
   const abortController = new AbortController();
 
   // Store abort controller for cancellation

--- a/server/src/routes/generate.ts
+++ b/server/src/routes/generate.ts
@@ -1172,6 +1172,19 @@ async function runGeneration(job: GenerationJob): Promise<void> {
         if (measured > 0) trackDuration = Math.round(measured);
       }
 
+      // Per-track generation_params. job.params.seed/lmSeed only reflect the
+      // job-level (first-track) value — when randomSeed varies the DiT seed
+      // per track (or the engine varies lm_seed per output in a live LM
+      // batch), later tracks would otherwise all show track 1's seed in the
+      // DB/UI even though a different one was actually used to synthesize
+      // them, making reproduction impossible. trackResult (== lmResults[i],
+      // mutated in place by the synth loop) holds the real per-track values.
+      const trackParams = {
+        ...job.params,
+        seed: trackResult.seed !== undefined ? trackResult.seed : job.params.seed,
+        lmSeed: trackResult.lm_seed !== undefined ? trackResult.lm_seed : job.params.lmSeed,
+      };
+
       const songId = uuidv4();
       getDb().prepare(`
         INSERT INTO songs (id, user_id, title, lyrics, style, caption, audio_url,
@@ -1181,7 +1194,7 @@ async function runGeneration(job: GenerationJob): Promise<void> {
       `).run(
         songId, job.userId, title, trackLyrics, style, trackCaption,
         audioUrl, trackDuration, bpm, keyScale, timeSignature,
-        JSON.stringify([]), aceReq.synth_model || '', JSON.stringify(job.params),
+        JSON.stringify([]), aceReq.synth_model || '', JSON.stringify(trackParams),
         trackMastered, trackLatent, qualityJson,
       );
       songIds.push(songId);

--- a/server/src/services/aceClient.ts
+++ b/server/src/services/aceClient.ts
@@ -44,6 +44,9 @@ export interface AceRequest {
   timesignature?: string;
   vocal_language?: string;
   seed?: number;
+  /** LM-phase sampling seed (caption/lyrics/audio-codes). Independent from
+   *  `seed`, which drives DiT synthesis. -1 or omitted lets the engine pick. */
+  lm_seed?: number;
   lm_batch_size?: number;
   synth_batch_size?: number;
   lm_temperature?: number;

--- a/server/src/services/generation/lmCache.ts
+++ b/server/src/services/generation/lmCache.ts
@@ -1,6 +1,6 @@
 // generation/lmCache.ts — LM audio code cache
 //
-// Caches ONLY LM-generated output fields keyed by seed + LM-affecting params.
+// Caches ONLY LM-generated output fields keyed by lm_seed + LM-affecting params.
 // Non-LM parameters (DiT, adapter, DCW, etc.) are NEVER cached.
 
 import crypto from 'crypto';
@@ -21,8 +21,13 @@ const lmCache = new Map<string, { lmOutputs: LmCacheEntry[]; timestamp: number }
 
 /** Compute a stable hash key from LM-affecting parameters */
 export function computeLmCacheKey(req: AceRequest): string {
+  // lm_seed is left unset on the request when the LM seed is tied to the
+  // DiT seed (the engine's own fallback then ties it) — use the effective
+  // value here too, or every tied request would collide on `undefined`
+  // regardless of the actual (possibly random) DiT seed.
+  const effectiveLmSeed = req.lm_seed !== undefined ? req.lm_seed : req.seed;
   const keyObj = {
-    seed: req.seed,
+    lm_seed: effectiveLmSeed,
     caption: req.caption,
     lyrics: req.lyrics,
     bpm: req.bpm,

--- a/server/src/services/generation/translateParams.ts
+++ b/server/src/services/generation/translateParams.ts
@@ -33,11 +33,23 @@ export function translateParams(params: any): AceRequest {
   }
   if (params.vocalLanguage) req.vocal_language = params.vocalLanguage;
 
-  // Seed
+  // Seed (DiT / generation phase)
   if (params.randomSeed) {
     req.seed = Math.floor(Math.random() * 2_147_483_647);
   } else if (params.seed !== undefined) {
     req.seed = params.seed;
+  }
+
+  // LM Seed — independent from the seed above, unless tied to it via
+  // lmSeedFollowsDit (default true — matches the engine's original
+  // behavior: locked seed -> both deterministic, random -> both random).
+  // When tied, lm_seed is left unset entirely so the engine's own fallback
+  // (lm_seed defaults to the DiT seed when absent) does the tying — this
+  // correctly follows a *randomized* seed too, since req.seed is already
+  // resolved above by this point.
+  const lmSeedFollowsDit = params.lmSeedFollowsDit !== false; // default true
+  if (!lmSeedFollowsDit && params.lmSeed !== undefined) {
+    req.lm_seed = params.lmSeed;
   }
 
   // Batch

--- a/ui/src/components/create/CreatePanel.tsx
+++ b/ui/src/components/create/CreatePanel.tsx
@@ -87,6 +87,8 @@ export const CreatePanel: React.FC<CreatePanelProps> = ({ onGenerate, activeJobC
     if (gpData.cacheRatio !== undefined) gp.setCacheRatio(gpData.cacheRatio);
     if (gpData.seed !== undefined) gp.setSeed(gpData.seed);
     if (gpData.randomSeed !== undefined) gp.setRandomSeed(gpData.randomSeed);
+    if (gpData.lmSeed !== undefined) gp.setLmSeed(gpData.lmSeed);
+    if (gpData.lmSeedFollowsDit !== undefined) gp.setLmSeedFollowsDit(gpData.lmSeedFollowsDit);
     if (gpData.shift !== undefined) gp.setShift(gpData.shift);
     if (gpData.inferMethod) gp.setInferMethod(gpData.inferMethod);
     if (gpData.scheduler) gp.setScheduler(gpData.scheduler);

--- a/ui/src/components/details/RightSidebar.tsx
+++ b/ui/src/components/details/RightSidebar.tsx
@@ -327,6 +327,18 @@ export const RightSidebar: React.FC<RightSidebarProps> = ({
                 />
               )}
 
+              {/* LM Seed — mono */}
+              {gp.lmSeed !== undefined && (
+                <ParamCell
+                  label="LM Seed"
+                  value={String(gp.lmSeed).substring(0, 12) + (String(gp.lmSeed).length > 12 ? '…' : '')}
+                  gradient="from-slate-500/10 to-zinc-500/10 border-slate-200 dark:border-slate-500/30"
+                  iconColor="text-slate-600 dark:text-slate-400"
+                  icon={<Hash size={12} />}
+                  mono
+                />
+              )}
+
               {/* Batch Size */}
               {gp.batchSize && gp.batchSize > 1 && (
                 <ParamCell

--- a/ui/src/components/global-bar/GenerationDropdown.tsx
+++ b/ui/src/components/global-bar/GenerationDropdown.tsx
@@ -742,7 +742,7 @@ export const GenerationDropdown: React.FC = () => {
       <div className="relative">
         <div className="flex items-center justify-between mb-1.5">
           <div className="flex items-center gap-1.5">
-            <label className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Seed</label>
+            <label className="text-xs font-medium text-zinc-500 uppercase tracking-wider">Generation Seed</label>
             <button onClick={() => setSeedDrawerOpen(true)} title="Seed Manager"
               className="text-zinc-500 hover:text-amber-400 transition-colors">
               <Save size={12} />
@@ -756,6 +756,9 @@ export const GenerationDropdown: React.FC = () => {
         {!gp.randomSeed && (
           <SeedInput value={gp.seed} onChange={gp.setSeed} className={inputClasses} />
         )}
+        <p className="text-[10px] text-zinc-500 mt-1">
+          Drives audio synthesis (DiT). Varies per track during batch generation. See LM Seed for caption/lyrics/code sampling.
+        </p>
         <SeedManagerDrawer
           isOpen={seedDrawerOpen}
           onClose={() => setSeedDrawerOpen(false)}
@@ -807,7 +810,7 @@ export const GenerationBadge: React.FC = () => {
 
   return (
     <span className="text-[10px] text-zinc-500 font-mono truncate">
-      {gp.inferenceSteps}s · {solver} · {schedule} · {guidance} {gp.guidanceScale.toFixed(1)} · σ{shiftLabel} · {seedLabel}
+      {gp.inferenceSteps}s · {solver} · {schedule} · {guidance} {gp.guidanceScale.toFixed(1)} · σ{shiftLabel} · Seed {seedLabel}
     </span>
   );
 };

--- a/ui/src/components/global-bar/GlobalParamBar.tsx
+++ b/ui/src/components/global-bar/GlobalParamBar.tsx
@@ -161,6 +161,8 @@ export const GlobalParamBar: React.FC = () => {
         if (p.guidanceMode !== undefined) gp.setGuidanceMode(p.guidanceMode);
         if (p.seed !== undefined) gp.setSeed(p.seed);
         if (p.randomSeed !== undefined) gp.setRandomSeed(p.randomSeed);
+        if (p.lmSeed !== undefined) gp.setLmSeed(p.lmSeed);
+        if (p.lmSeedFollowsDit !== undefined) gp.setLmSeedFollowsDit(p.lmSeedFollowsDit);
         if (p.batchSize !== undefined) gp.setBatchSize(p.batchSize);
         if (p.useCotCaption !== undefined) gp.setUseCotCaption(p.useCotCaption);
         if (p.skipLm !== undefined) gp.setSkipLm(p.skipLm);

--- a/ui/src/components/global-bar/LmThinkingDropdown.tsx
+++ b/ui/src/components/global-bar/LmThinkingDropdown.tsx
@@ -3,17 +3,34 @@
 // The on/off toggle is in the bar header (ToggleSwitch).
 // This dropdown only shows the detailed LM parameters when LM is enabled.
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Save } from 'lucide-react';
 import { useGlobalParams } from '../../context/GlobalParamsContext';
 import { Slider } from '../shared/Slider';
 import { ToggleSwitch } from './BarSection';
+import { SeedManagerDrawer } from './SeedManagerDrawer';
 
 const inputClasses = "w-full px-3 py-2 rounded-xl bg-zinc-100 dark:bg-zinc-800 border border-zinc-300 dark:border-white/10 text-sm text-zinc-800 dark:text-zinc-200 focus:border-pink-500/50 focus:ring-1 focus:ring-pink-500/20 outline-none transition-colors";
+
+/** Seed input with local string buffer — prevents parseInt("-") snap-back */
+const SeedInput: React.FC<{ value: number; onChange: (v: number) => void; className: string }> = ({ value, onChange, className }) => {
+  const [local, setLocal] = useState(String(value));
+  useEffect(() => { setLocal(String(value)); }, [value]);
+  const commit = () => { onChange(parseInt(local) || 42); };
+  return (
+    <input type="number" className={className} value={local}
+      onChange={e => setLocal(e.target.value)}
+      onBlur={commit}
+      onKeyDown={e => { if (e.key === 'Enter') commit(); }}
+    />
+  );
+};
 
 export const LmThinkingDropdown: React.FC = () => {
   const gp = useGlobalParams();
   const { t } = useTranslation();
+  const [seedDrawerOpen, setSeedDrawerOpen] = useState(false);
 
   if (gp.skipLm) {
     return (
@@ -52,19 +69,56 @@ export const LmThinkingDropdown: React.FC = () => {
 
       <Slider label="LM Codes Strength" value={gp.lmCodesStrength}
         onChange={gp.setLmCodesStrength} min={0} max={1} step={0.05} showInput />
+
+      {/* LM Seed — independent from the Generation (DiT) seed by default,
+          unless "Use DiT Seed" is on, which ties lm_seed to the DiT seed
+          (the original engine behavior: locked seed -> both deterministic,
+          random -> both random). */}
+      <div className="relative">
+        <div className="flex items-center justify-between mb-1.5">
+          <div className="flex items-center gap-1.5">
+            <label className="text-xs font-medium text-zinc-500 uppercase tracking-wider">LM Seed</label>
+            <button onClick={() => setSeedDrawerOpen(true)} title="Seed Manager"
+              className="text-zinc-500 hover:text-amber-400 transition-colors">
+              <Save size={12} />
+            </button>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-zinc-500">Use DiT Seed</span>
+            <ToggleSwitch checked={gp.lmSeedFollowsDit} onChange={gp.setLmSeedFollowsDit} accentColor="sky" />
+          </div>
+        </div>
+        {!gp.lmSeedFollowsDit && (
+          <SeedInput value={gp.lmSeed} onChange={gp.setLmSeed} className={inputClasses} />
+        )}
+        <p className="text-[10px] text-zinc-500 mt-1">
+          {gp.lmSeedFollowsDit
+            ? 'Tied to the Generation seed — locked seed means both are deterministic, random means both are random.'
+            : 'Drives caption/lyrics/audio-code sampling independently of the Generation seed.'}
+        </p>
+        <SeedManagerDrawer
+          isOpen={seedDrawerOpen}
+          onClose={() => setSeedDrawerOpen(false)}
+          currentSeed={gp.lmSeed}
+          onLoad={(seed) => { gp.setLmSeed(seed); gp.setLmSeedFollowsDit(false); setSeedDrawerOpen(false); }}
+          onLoadRandom={(seed) => { gp.setLmSeed(seed); gp.setLmSeedFollowsDit(false); }}
+        />
+      </div>
     </div>
   );
 };
 
 /** Summary badge for the LM / Thinking section */
 export const LmThinkingBadge: React.FC = () => {
-  const { skipLm, useCotCaption, lmTemperature, lmCfgScale, lmCodesStrength } = useGlobalParams();
+  const { skipLm, useCotCaption, lmTemperature, lmCfgScale, lmCodesStrength, lmSeedFollowsDit } = useGlobalParams();
 
   if (skipLm) return null;
 
+  const seedLabel = lmSeedFollowsDit ? 'DiT' : 'Fix';
+
   return (
     <span className="text-[10px] text-zinc-500 font-mono truncate">
-      {useCotCaption ? 'CoT · ' : ''}T{lmTemperature.toFixed(2)} · CFG {lmCfgScale.toFixed(1)}{lmCodesStrength < 1.0 ? ` · CS ${lmCodesStrength.toFixed(2)}` : ''}
+      {useCotCaption ? 'CoT · ' : ''}T{lmTemperature.toFixed(2)} · CFG {lmCfgScale.toFixed(1)}{lmCodesStrength < 1.0 ? ` · CS ${lmCodesStrength.toFixed(2)}` : ''} · Seed {seedLabel}
     </span>
   );
 };

--- a/ui/src/components/library/SongList.tsx
+++ b/ui/src/components/library/SongList.tsx
@@ -1389,6 +1389,7 @@ const BASE_COLS: ColDef[] = [
   { id: 'date',    label: 'Date',    defaultW: 80,  minW: 50,  align: 'left', resizable: true },
   // ── Generation data (hidden by default; enable via Columns menu) ──
   { id: 'seed',      label: 'Seed',      defaultW: 96,  minW: 60, align: 'left', resizable: true, defaultHidden: true },
+  { id: 'lmSeed',    label: 'LM Seed',   defaultW: 96,  minW: 60, align: 'left', resizable: true, defaultHidden: true },
   { id: 'steps',     label: 'Steps',     defaultW: 56,  minW: 44, align: 'left', resizable: true, defaultHidden: true },
   { id: 'cfg',       label: 'CFG',       defaultW: 56,  minW: 44, align: 'left', resizable: true, defaultHidden: true },
   { id: 'shift',     label: 'Shift',     defaultW: 56,  minW: 44, align: 'left', resizable: true, defaultHidden: true },
@@ -1405,6 +1406,7 @@ const BASE_COLS: ColDef[] = [
   { id: 'instrumental', label: 'Instr.', defaultW: 60, minW: 48, align: 'center', resizable: true, defaultHidden: true },
   { id: 'mastered',  label: 'Mastered',  defaultW: 76,  minW: 56, align: 'center', resizable: true, defaultHidden: true },
   { id: 'seedType',  label: 'Seed Type', defaultW: 80,  minW: 56, align: 'left', resizable: true, defaultHidden: true },
+  { id: 'lmSeedType', label: 'LM Seed Type', defaultW: 90, minW: 60, align: 'left', resizable: true, defaultHidden: true },
   // Holds up to 5 action buttons (edit/download/delete/A/B). Must be wide
   // enough that the fixed-layout <td overflow-hidden> never clips them — the
   // column is non-resizable so the user can't widen it manually (#58).
@@ -1685,6 +1687,7 @@ const SongTable: React.FC<SongTableProps> = ({
               date: <span className="text-zinc-600">{formatDate(song.created_at || song.createdAt)}</span>,
               // ── Generation data (hidden by default) ──
               seed: <span className="text-zinc-500 font-mono truncate block">{gp?.seed ?? '—'}</span>,
+              lmSeed: <span className="text-zinc-500 font-mono truncate block">{gp?.lmSeed ?? '—'}</span>,
               steps: <span className="text-zinc-500 font-mono">{gp?.inferenceSteps ?? '—'}</span>,
               cfg: <span className="text-zinc-500 font-mono">{gp?.guidanceScale ?? '—'}</span>,
               shift: <span className="text-zinc-500 font-mono">{gp?.shift ?? '—'}</span>,
@@ -1701,6 +1704,7 @@ const SongTable: React.FC<SongTableProps> = ({
               instrumental: <span className="text-zinc-500">{gp?.instrumental ? 'Yes' : (gp?.instrumental === false ? 'No' : '—')}</span>,
               mastered: isMastered ? <Check size={13} className="text-emerald-400 inline" /> : <span className="text-zinc-600">—</span>,
               seedType: <span className="text-zinc-500">{gp?.randomSeed === true ? 'Random' : (gp?.randomSeed === false ? 'Fixed' : '—')}</span>,
+              lmSeedType: <span className="text-zinc-500">{gp?.lmSeedFollowsDit === true ? 'Tied to DiT' : (gp?.lmSeedFollowsDit === false ? 'Fixed' : '—')}</span>,
               actions: (
                 <div className="flex items-center justify-end gap-0.5 flex-nowrap flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
                   {onReuse && (

--- a/ui/src/components/shared/ABCompareModal.tsx
+++ b/ui/src/components/shared/ABCompareModal.tsx
@@ -93,7 +93,7 @@ const PARAM_LABELS: Record<string, string> = {
 // Keys to skip in comparison (always different or internal)
 const SKIP_KEYS = new Set([
   'prompt', 'lyrics', 'title', 'caption', 'songDescription', 'customMode',
-  'randomSeed', 'seed', 'source', 'style', 'artist', 'subject', 'trackName',
+  'randomSeed', 'seed', 'lmSeedFollowsDit', 'lmSeed', 'source', 'style', 'artist', 'subject', 'trackName',
   'sourceAudioUrl', 'sourceLatentUrl', 'lmNegativePrompt',
   'pluginParams',  // shown separately if needed
   'adapterGroupScales',

--- a/ui/src/context/GlobalParamsContext.tsx
+++ b/ui/src/context/GlobalParamsContext.tsx
@@ -63,6 +63,10 @@ export interface GlobalParams {
   guidanceMode: string; setGuidanceMode: (v: string) => void;
   seed: number; setSeed: (v: number) => void;
   randomSeed: boolean; setRandomSeed: (v: boolean) => void;
+  // LM Seed — independent from seed/randomSeed above; drives LM-phase
+  // sampling. When lmSeedFollowsDit is true, it's tied to `seed` instead.
+  lmSeed: number; setLmSeed: (v: number) => void;
+  lmSeedFollowsDit: boolean; setLmSeedFollowsDit: (v: boolean) => void;
   batchSize: number; setBatchSize: (v: number) => void;
   // Solver sub-params
   storkSubsteps: number; setStorkSubsteps: (v: number) => void;

--- a/ui/src/stores/globalParamsStore.ts
+++ b/ui/src/stores/globalParamsStore.ts
@@ -88,6 +88,10 @@ export const useGlobalParamsStore = create<any>()((set, get) => ({
   guidanceMode: readKey("hs-guidanceMode", 'apg'),
   seed: readKey("hs-seed", 42),
   randomSeed: readKey("hs-randomSeed", true),
+  // LM Seed — independent of the DiT/generation seed above, unless tied
+  // via lmSeedFollowsDit (default true = original tied behavior).
+  lmSeed: readKey("hs-lmSeed", 42),
+  lmSeedFollowsDit: readKey("hs-lmSeedFollowsDit", true),
   batchSize: readKey("hs-batchSize", 1),
   storkSubsteps: readKey("hs-storkSubsteps", 10),
   beatStability: readKey("hs-beatStability", 0.25),
@@ -224,6 +228,8 @@ export const useGlobalParamsStore = create<any>()((set, get) => ({
       set({ seed: 42 }); writeKey("hs-seed", 42);
     }
   },
+  setLmSeed: (v: any) => { set({ lmSeed: v }); writeKey("hs-lmSeed", v); },
+  setLmSeedFollowsDit: (v: any) => { set({ lmSeedFollowsDit: v }); writeKey("hs-lmSeedFollowsDit", v); },
   setBatchSize: (v: any) => { set({ batchSize: v }); writeKey("hs-batchSize", v); },
   setStorkSubsteps: (v: any) => { set({ storkSubsteps: v }); writeKey("hs-storkSubsteps", v); },
   setBeatStability: (v: any) => { set({ beatStability: v }); writeKey("hs-beatStability", v); },
@@ -386,7 +392,9 @@ export const useGlobalParamsStore = create<any>()((set, get) => ({
       lmCfgCutoffRatio: s.lmCfgCutoffRatio < 1.0 ? s.lmCfgCutoffRatio : undefined,
       cacheRatio: s.cacheRatio > 0 ? s.cacheRatio : undefined,
       inferMethod: s.inferMethod, scheduler: s.scheduler, guidanceMode: s.guidanceMode,
-      seed: s.seed, randomSeed: s.randomSeed, batchSize: s.batchSize,
+      seed: s.seed, randomSeed: s.randomSeed,
+      lmSeed: s.lmSeed, lmSeedFollowsDit: s.lmSeedFollowsDit,
+      batchSize: s.batchSize,
       storkSubsteps: (s.inferMethod === 'stork2' || s.inferMethod === 'stork4') ? s.storkSubsteps : undefined,
       beatStability: s.inferMethod === 'jkass_fast' ? s.beatStability : undefined,
       frequencyDamping: s.inferMethod === 'jkass_fast' ? s.frequencyDamping : undefined,

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -114,9 +114,18 @@ export interface GenerationParams {
   scheduler: string;
   guidanceMode: string;
 
-  // Seed
+  // Seed (DiT / generation phase)
   seed: number;
   randomSeed: boolean;
+
+  // LM Seed — independent from the seed above. Controls the LM phase's
+  // caption/lyrics/audio-code sampling. When lmSeedFollowsDit is true
+  // (default), lmSeed is ignored and the LM seed is tied to the DiT seed —
+  // the original engine behavior: locked seed -> both deterministic,
+  // random -> both random. Set lmSeedFollowsDit to false to use lmSeed as
+  // an independent fixed value instead.
+  lmSeed?: number;
+  lmSeedFollowsDit?: boolean;
 
   // Batch
   batchSize: number;


### PR DESCRIPTION
This PR aims to add the ability to use different seeds for DiT (anything except LM) and LM generations.
Why? Simple: Batch generation uses the same seed for LM and different seeds for anything else -> a batch-generated sample can't be reproduced with higher step count even if the seed is known. This new mode should enable users to enter two different seeds, thus enabling reproduction of batched samples.
If original functionality is needed (so both seeds are the same), it can be switched back with a toggle.
Custom seed             |  Original behaviour
:-------------------------:|:-------------------------:
<img width="480" height="847" alt="image" src="https://github.com/user-attachments/assets/90fe61e1-bd0e-44ae-a21e-7a5b1fd8d469" />  |  <img width="476" height="788" alt="image" src="https://github.com/user-attachments/assets/e52ca489-3b67-487b-b7a3-0b9935d3a2ef" />


This led to a discovery of another issue: batch-generated songs shared the seed of the first item regardless of their own seed. With default random seeds, this made reproduction really hard. With the second commit of this PR, this issue should be solved: every song displays it's own seed after checking their card.
<img width="455" height="502" alt="image" src="https://github.com/user-attachments/assets/48a5b87c-e727-4fde-89e2-68573a317937" />
