### PR TITLE
Add ROCm/HIP support

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.14)
-project(acestep-ggml LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.21)
+project(acestep-ggml LANGUAGES C CXX HIP)
 
 # CI cache generation: 2 (2026-07-16). This file is hashed into the GitHub
 # Actions build-cache key — bump this comment to force cold builds when the
@@ -106,6 +106,14 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
             list(APPEND CMAKE_CUDA_ARCHITECTURES "121a-real")
         endif()
     endif()
+endif()
+
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm)
+find_package(hip CONFIG QUIET)
+
+if(hip_FOUND)
+    message(STATUS "building with AMD ROCm support")
+    add_compile_definitions(__HIP_PLATFORM_AMD__)
 endif()
 
 # Disable flash attention (cuda12-volta variant). ggml's mma flash-attention has
@@ -308,7 +316,11 @@ add_library(acestep-core STATIC
     src/pipeline-synth-ops.cpp
     src/pipeline-understand.cpp
 )
-target_link_libraries(acestep-core PUBLIC yyjson lua54 supersep)
+if(hip_FOUND)
+   target_link_libraries(acestep-core PUBLIC yyjson lua54 supersep hip::host)
+else()
+   target_link_libraries(acestep-core PUBLIC yyjson lua54 supersep)
+endif()
 link_ggml_backends(acestep-core)
 
 # ONNX Runtime for the paths that still use it: sa3-refine.h (StableStep's ONNX
@@ -448,7 +460,11 @@ set_source_files_properties(${WEBUI_OUTPUT} PROPERTIES GENERATED TRUE)
 #       Our server binary is hot-step-server.cpp with extension layer support.
 add_executable(ace-server tools/hot-step-server.cpp ${WEBUI_OUTPUT})
 target_include_directories(ace-server PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(ace-server PRIVATE acestep-core httplib supersep)
+if(hip_FOUND)
+    target_link_libraries(ace-server PRIVATE acestep-core httplib supersep hip::host)
+else()
+    target_link_libraries(ace-server PRIVATE acestep-core httplib supersep)
+endif()
 link_ggml_backends(ace-server)
 # CUDA runtime for GET /vram (cudaMemGetInfo)
 find_package(CUDAToolkit QUIET)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(acestep-ggml LANGUAGES C CXX HIP)
+project(acestep-ggml LANGUAGES C CXX)
 
 # CI cache generation: 2 (2026-07-16). This file is hashed into the GitHub
 # Actions build-cache key — bump this comment to force cold builds when the

--- a/engine/buildhip.sh
+++ b/engine/buildhip.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+rm -rf build
+mkdir build
+cd build
+
+if command -v rocminfo; then export GFX_NAME=$(rocminfo | awk '/ *Name: +gfx[1-9]/ {print $2; exit}'); else echo "rocminfo missing!"; fi
+if [ -z "${GFX_NAME}" ]; then 
+   echo "Warn: Couldn't detect AMD GPU for HIP! Using fallback value (gfx1030)."; 
+   GFX_NAME="gfx1030";
+else 
+   echo "Building for GPU arch: ${GFX_NAME}"; 
+fi
+
+cmake .. -DGGML_HIP=ON -DGPU_TARGETS=$GFX_NAME -DCMAKE_BUILD_TYPE=Release
+cmake --build . --config Release -j `nproc --ignore=1`

--- a/engine/src/gpu.h
+++ b/engine/src/gpu.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#if defined (GGML_USE_CUDA)
+  #if defined (__HIP_PLATFORM_AMD__)
+     #include <hip/hip_runtime.h>
+     #define cudaMemGetInfo hipMemGetInfo
+     #define cudaGetErrorString hipGetErrorString
+     #define cudaError_t hipError_t
+     #define cudaSuccess hipSuccess
+  #else defined (GGML_USE_CUDA)
+     #include <cuda_runtime.h>
+  #endif
+#endif

--- a/engine/src/gpu.h
+++ b/engine/src/gpu.h
@@ -7,7 +7,7 @@
      #define cudaGetErrorString hipGetErrorString
      #define cudaError_t hipError_t
      #define cudaSuccess hipSuccess
-  #else defined (GGML_USE_CUDA)
+  #else
      #include <cuda_runtime.h>
   #endif
 #endif

--- a/engine/src/pipeline-synth.cpp
+++ b/engine/src/pipeline-synth.cpp
@@ -29,8 +29,9 @@
 
 // VRAM instrumentation: total GPU usage at pipeline phase boundaries, so we can
 // see the split between model weights, DiT activations and VAE-decode buffers.
+
 #ifdef GGML_USE_CUDA
-#include <cuda_runtime.h>
+#include "gpu.h"
 static void diag_vram(const char * label) {
     size_t free_b = 0, total_b = 0;
     if (cudaMemGetInfo(&free_b, &total_b) == cudaSuccess) {

--- a/engine/tools/hot-step-server.cpp
+++ b/engine/tools/hot-step-server.cpp
@@ -105,7 +105,7 @@ static volatile int * _hotstep_guard_ = &hotstep_sampler_linked_;
 #endif
 
 #ifdef GGML_USE_CUDA
-#    include <cuda_runtime_api.h>
+#    include "../src/gpu.h"
 #endif
 
 // portable fd wrappers. avoids macros that collide with C++ method names


### PR DESCRIPTION
Added aliases for CUDA functions for sucessful builds on ROCm/HIP without changing CUDA-using code.
Added shell script to compile engine for ROCm/HIP (buildhip.sh)
Required cmake version pushed from 3.14 to 3.21 because ROCm SDK needs 3.21

Created file for platform-dependent GPU code: src/gpu.h